### PR TITLE
Chore/use fqcn rapidpro

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2004-2022, University of Oslo
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the HISP project nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deploy/playbooks/rapidpro.yml
+++ b/deploy/playbooks/rapidpro.yml
@@ -3,18 +3,18 @@
   hosts: all
   become: true
   vars:
-     rapidpro_version: 7.0.7
-     rapidpro_url: https://github.com/rapidpro/rapidpro/archive/v{{ rapidpro_version }}.tar.gz
-     rapidpro_home: /opt/rapidpro
-     rapidpro_user: rapidpro
-     rapidpro_group: rapidpro
+    rapidpro_version: 7.0.7
+    rapidpro_url: https://github.com/rapidpro/rapidpro/archive/v{{ rapidpro_version }}.tar.gz
+    rapidpro_home: /opt/rapidpro
+    rapidpro_user: rapidpro
+    rapidpro_group: rapidpro
   tasks:
     - name: Update apt cache
-      apt:
-        update_cache: yes
+      ansible.builtin.apt:
+        update_cache: true
 
     - name: Install required packages
-      apt:
+      ansible.builtin.apt:
         name:
           - python3-dev
           - libmysqlclient-dev
@@ -26,47 +26,51 @@
         state: present
 
     - name: Create rapidpro user and group
-      group:
+      ansible.builtin.group:
         name: "{{ rapidpro_group }}"
         state: present
 
     - name: "Create rapidpro user"
-      user:
+      ansible.builtin.user:
         name: "{{ rapidpro_user }}"
         group: "{{ rapidpro_group }}"
         home: "{{ rapidpro_home }}"
         shell: /bin/bash
-        create_home: yes
-        system: yes
+        create_home: true
+        system: true
         state: present
 
     - name: Install virtualenv
-      pip:
+      ansible.builtin.pip:
         name: virtualenv
         executable: pip3
         state: present
 
     - name: Create virtual environment for RapidPro
-      command: virtualenv -p python3 "{{ rapidpro_home }}/venv"
+      ansible.builtin.command: virtualenv -p python3 "{{ rapidpro_home }}/venv"
       args:
         creates: "{{ rapidpro_home }}/venv"
 
     - name: Download and extract RapidPro
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ rapidpro_url }}"
         dest: /tmp/rapidpro.tar.gz
-        mode: '0644'
+        mode: "0644"
 
-    - command: tar xzf /tmp/rapidpro.tar.gz --strip 1 -C "{{ rapidpro_home }}"
+    - name: Extract RapidPro
+      ansible.builtin.unarchive:
+        src: /tmp/rapidpro.tar.gz
+        dest: "{{ rapidpro_home }}"
+        extra_opts: "--strip 1"
 
     - name: Install RapidPro requirements
-      pip:
+      ansible.builtin.pip:
         requirements: "{{ rapidpro_home }}/requirements/base.txt"
         executable: "{{ rapidpro_home }}/venv/bin/pip"
         state: present
 
     - name: Set file permissions
-      file:
+      ansible.builtin.file:
         path: "{{ item }}"
         owner: "{{ rapidpro_user }}"
         group: "{{ rapidpro_group }}"
@@ -83,27 +87,28 @@
         - "{{ rapidpro_home }}/src/temba/*"
 
     - name: Configure Nginx
-      copy:
+      ansible.builtin.copy:
         src: rapidpro-nginx.conf
         dest: /etc/nginx/sites-available/rapidpro
         owner: root
         group: root
-        mode: '0644'
+        mode: "0644"
 
     - name: Enable Nginx site
-      file:
+      ansible.builtin.file:
         src: /etc/nginx/sites-available/rapidpro
         dest: /etc/nginx/sites-enabled/rapidpro
         state: link
 
     - name: Create supervisor configuration file
-      copy:
+      ansible.builtin.copy:
         src: rapidpro-supervisor.conf
         dest: /etc/supervisor/conf.d/rapidpro.conf
         owner: root
         group: root
-        mode: '0644'
+        mode: "0644"
 
     - name: Reload supervisor
-      supervisorctl:
+      community.general.supervisorctl:
+        name: rapidpro
         state: restarted


### PR DESCRIPTION
This PR is initial part of a major refactor in preparations to adding tests and linting to the tools. We start by using Ansible Fully Qualified Collection Names in the rapidpro playbook, which was the only playbook that was not using FQCN to call ansible builtin modules.

- Converts module names to Ansible FQCN
- Uses the community.general collection for the supervisor module