### PR TITLE
chore: change release type to node

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,7 @@
     "include-v-in-tag": true,
     "packages": {
         ".": {
-            "release-type": "simple",
+            "release-type": "node",
             "package-name": "dhis2-server-tools",
             "changelog-type": "default",
             "versioning": "default",


### PR DESCRIPTION
changes release type to "node"