### PR TITLE
feat: add opt-in ClamAV upload scanning

### DIFF
--- a/changelogs/fragments/clamav-upload-scanning.yml
+++ b/changelogs/fragments/clamav-upload-scanning.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - |
+    Add opt-in ClamAV upload scanning
+    (``clamav_enabled``, ``[clamav_servers]``).
+    The reverse proxy sends DHIS2 file-create URLs to a scan-and-forward
+    gateway co-located with clamd. Default deploys are unchanged.

--- a/deploy/dhis2.yml
+++ b/deploy/dhis2.yml
@@ -24,6 +24,9 @@
       tags: [proxy-install]
     - role: monitoring
       tags: monitoring
+    - role: clamav
+      tags: [clamav]
+      when: clamav_enabled | default(false) | bool
     - role: create-instance
       tags: [create-instance]
       when: instance_state is not defined or instance_state != 'deleted'

--- a/deploy/filter_plugins/custom_filters.py
+++ b/deploy/filter_plugins/custom_filters.py
@@ -132,6 +132,14 @@ def tomcat_version(distribution_version):
         return 9
 
 
+def hostport(addr, port):
+    """Format addr:port, wrapping IPv6 literals in brackets."""
+    a = str(addr or "")
+    if ":" in a and not a.startswith("["):
+        return f"[{a}]:{port}"
+    return f"{a}:{port}"
+
+
 def external_hosts(hosts, hostvars, lxd_network):
     """Return hosts whose ansible_host is not in lxd_network."""
     network = IPNetwork(lxd_network)
@@ -154,4 +162,5 @@ class FilterModule(object):
                 'tomcat_version': tomcat_version,
                 'normalize_dhis2_version': normalize_dhis2_version,
                 'all_have_fqdn': all_have_fqdn,
+                'hostport': hostport,
                 }

--- a/deploy/inventory/hosts.template
+++ b/deploy/inventory/hosts.template
@@ -34,6 +34,11 @@ backup  ansible_host=172.19.2.100
 # integration server/container
 [integration]
 
+# Optional upload scanner. Enabling needs ~4 GiB extra RAM and clamav_enabled=true.
+# Do not use wireguard_ip=10.0.0.6 — that is the default sysadmin peer.
+[clamav_servers]
+# clamav  ansible_host=172.19.2.40  wireguard_ip=10.0.0.8
+
 # variables applying to all hosts, 
 [all:vars]
 # if you do not set fqdn, you dhis2 will be set up with selfsigned certificate
@@ -62,6 +67,13 @@ app_monitoring=glowroot
 wireguard_enabled=false
 # wireguard_data_plane=false
 
+# Upload scanning (needs a [clamav_servers] host and ~4 GiB extra RAM; see docs/clamav.md)
+# clamav_enabled=false
+# clamav_fail_open=false
+# clamav_scan_app_zips=true
+# clamav_scan_ui_assets=true
+# clamav_gateway_port=8081
+# clamav_private_mirror=
 
 # lxd
 lxd_network=172.19.2.1/24 

--- a/deploy/roles/clamav/defaults/main.yml
+++ b/deploy/roles/clamav/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+clamav_enabled: false
+clamav_fail_open: false
+clamav_scan_app_zips: true
+clamav_scan_ui_assets: true
+clamav_gateway_port: 8081
+clamav_private_mirror: ""
+
+clamav_lxd_memory: 4GiB
+clamav_min_host_mem_available_kb: 4194304
+clamav_gateway_user: clamav-gateway
+clamav_spool_dir: /var/spool/clamav-gateway
+clamav_socket: /var/run/clamav/clamd.ctl
+clamav_db_dir: /var/lib/clamav
+clamav_max_body_bytes: 104857600
+clamav_stream_max_length: 100M
+clamav_max_file_size: 100M
+clamav_max_scan_size: 150M
+clamav_max_scan_time: 120000
+clamav_max_files: 10000
+clamav_max_recursion: 16

--- a/deploy/roles/clamav/files/clamav_gateway.py
+++ b/deploy/roles/clamav/files/clamav_gateway.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Scan-and-forward gateway for DHIS2 file uploads.
+
+POST/PUT bodies are spooled and scanned via clamd's unix socket.
+multipart/form-data file parts are extracted and scanned as raw bytes so
+file-hash signatures (including EICAR) match; the original request is
+forwarded unchanged so DHIS2's MD5 still matches. Non-mutating
+methods on the same URLs are proxied with no scan. The reverse proxy
+overwrites X-DHIS2-Upstream; this process only connects to allowlisted
+instance addresses.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterable
+from urllib.parse import urlsplit
+
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "proxy-connection",
+}
+
+SCAN_METHODS = {"POST", "PUT"}
+DEFAULT_MAX_BODY = 104857600
+DEFAULT_SCAN_TIMEOUT = 120.0
+DEFAULT_FORWARD_TIMEOUT = 300.0
+SIGNATURE_FILES = (
+    "daily.cvd",
+    "daily.cld",
+    "main.cvd",
+    "main.cld",
+    "bytecode.cvd",
+    "bytecode.cld",
+)
+
+
+class ScannerDown(Exception):
+    """clamd is unreachable or returned an error."""
+
+
+class Infected(Exception):
+    def __init__(self, signature: str) -> None:
+        super().__init__(signature)
+        self.signature = signature
+
+
+@dataclass
+class GatewayConfig:
+    listen_host: str = "0.0.0.0"
+    listen_port: int = 8081
+    clamd_socket: str = "/var/run/clamav/clamd.ctl"
+    spool_dir: str = "/var/spool/clamav-gateway"
+    fail_open: bool = False
+    upstreams: frozenset[str] = field(default_factory=frozenset)
+    max_body: int = DEFAULT_MAX_BODY
+    db_dir: str = "/var/lib/clamav"
+    scan_timeout: float = DEFAULT_SCAN_TIMEOUT
+    forward_timeout: float = DEFAULT_FORWARD_TIMEOUT
+
+
+@dataclass
+class Metrics:
+    scans: int = 0
+    infected: int = 0
+    scan_seconds_sum: float = 0.0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def record_scan(self, duration: float, infected: bool) -> None:
+        with self.lock:
+            self.scans += 1
+            self.scan_seconds_sum += duration
+            if infected:
+                self.infected += 1
+
+
+def config_from_env(env: dict[str, str] | None = None) -> GatewayConfig:
+    src = env if env is not None else os.environ
+    raw_upstreams = src.get("CLAMAV_UPSTREAMS", "")
+    upstreams = frozenset(
+        part.strip() for part in raw_upstreams.split(",") if part.strip()
+    )
+    return GatewayConfig(
+        listen_host=src.get("CLAMAV_LISTEN_HOST", "0.0.0.0"),
+        listen_port=int(src.get("CLAMAV_LISTEN_PORT", "8081")),
+        clamd_socket=src.get("CLAMAV_SOCKET", "/var/run/clamav/clamd.ctl"),
+        spool_dir=src.get("CLAMAV_SPOOL_DIR", "/var/spool/clamav-gateway"),
+        fail_open=src.get("CLAMAV_FAIL_OPEN", "false").lower() in ("1", "true", "yes"),
+        upstreams=upstreams,
+        max_body=int(src.get("CLAMAV_MAX_BODY", str(DEFAULT_MAX_BODY))),
+        db_dir=src.get("CLAMAV_DB_DIR", "/var/lib/clamav"),
+        scan_timeout=float(src.get("CLAMAV_SCAN_TIMEOUT", str(DEFAULT_SCAN_TIMEOUT))),
+        forward_timeout=float(
+            src.get("CLAMAV_FORWARD_TIMEOUT", str(DEFAULT_FORWARD_TIMEOUT))
+        ),
+    )
+
+
+def parse_upstream_header(value: str | None) -> str | None:
+    """Return host:port from X-DHIS2-Upstream, or None if missing/unusable."""
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    if "://" not in raw:
+        raw = "http://" + raw
+    parts = urlsplit(raw)
+    if not parts.hostname:
+        return None
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{host}:{port}"
+
+
+def allowlisted(upstream: str | None, allowed: Iterable[str]) -> bool:
+    if not upstream:
+        return False
+    return upstream in set(allowed)
+
+
+def copy_limited(reader, handle, remaining: int, chunk_size: int = 65536) -> int:
+    while remaining > 0:
+        chunk = reader.read(min(chunk_size, remaining))
+        if not chunk:
+            break
+        handle.write(chunk)
+        remaining -= len(chunk)
+    return remaining
+
+
+def _clamd_session(socket_path: str, timeout: float) -> socket.socket:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect(socket_path)
+    except OSError:
+        sock.close()
+        raise
+    return sock
+
+
+def _recv_all(sock: socket.socket, limit: int = 65536) -> bytes:
+    chunks = []
+    received = 0
+    while received < limit:
+        data = sock.recv(4096)
+        if not data:
+            break
+        chunks.append(data)
+        received += len(data)
+        if data.endswith(b"\x00") or data.endswith(b"\n"):
+            break
+    return b"".join(chunks)
+
+
+def clamd_ping(socket_path: str, timeout: float = 5.0) -> bool:
+    try:
+        sock = _clamd_session(socket_path, timeout)
+    except OSError:
+        return False
+    try:
+        sock.sendall(b"zPING\0")
+        reply = _recv_all(sock).decode("utf-8", "replace")
+        return "PONG" in reply
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def _parse_scan_reply(reply: str) -> None:
+    text = reply.strip().rstrip("\x00")
+    if text.endswith("OK") and "FOUND" not in text:
+        return
+    if "FOUND" in text:
+        # /path: Eicar-Signature FOUND
+        signature = text.rsplit("FOUND", 1)[0].split(":", 1)[-1].strip()
+        raise Infected(signature or "unknown")
+    raise ScannerDown(text or "empty clamd reply")
+
+
+def clamd_scan_path(socket_path: str, path: str, timeout: float) -> None:
+    sock = _clamd_session(socket_path, timeout)
+    try:
+        sock.sendall(b"zSCAN " + path.encode("utf-8", "surrogateescape") + b"\0")
+        reply = _recv_all(sock).decode("utf-8", "replace")
+        if "Access denied" in reply or "lstat() failed" in reply:
+            raise PermissionError(reply)
+        _parse_scan_reply(reply)
+    finally:
+        sock.close()
+
+
+def clamd_instream(socket_path: str, path: str, timeout: float) -> None:
+    sock = _clamd_session(socket_path, timeout)
+    try:
+        sock.sendall(b"zINSTREAM\0")
+        with open(path, "rb") as handle:
+            while True:
+                chunk = handle.read(8192)
+                if not chunk:
+                    break
+                sock.sendall(struct.pack(">I", len(chunk)) + chunk)
+        sock.sendall(struct.pack(">I", 0))
+        reply = _recv_all(sock).decode("utf-8", "replace")
+        _parse_scan_reply(reply)
+    finally:
+        sock.close()
+
+
+def scan_spool(socket_path: str, path: str, timeout: float) -> None:
+    try:
+        clamd_scan_path(socket_path, path, timeout)
+    except PermissionError:
+        clamd_instream(socket_path, path, timeout)
+
+
+def _header_boundary(content_type: str | None) -> str | None:
+    if not content_type:
+        return None
+    for item in content_type.split(";"):
+        item = item.strip()
+        if item.lower().startswith("boundary="):
+            value = item.split("=", 1)[1].strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            return value or None
+    return None
+
+
+def multipart_filename_bodies(data: bytes, content_type: str | None) -> list[bytes]:
+    """Return file-part payloads from multipart/form-data, else []."""
+    ctype = (content_type or "").split(";", 1)[0].strip().lower()
+    boundary = _header_boundary(content_type)
+    if ctype != "multipart/form-data" or not boundary:
+        return []
+    delim = b"--" + boundary.encode("ascii", "surrogateescape")
+    bodies: list[bytes] = []
+    for chunk in data.split(delim)[1:]:
+        if chunk.startswith(b"--"):
+            break
+        if chunk.startswith(b"\r\n"):
+            chunk = chunk[2:]
+        elif chunk.startswith(b"\n"):
+            chunk = chunk[1:]
+        header_end = chunk.find(b"\r\n\r\n")
+        sep = 4
+        if header_end < 0:
+            header_end = chunk.find(b"\n\n")
+            sep = 2
+        if header_end < 0:
+            continue
+        headers = chunk[:header_end].decode("latin-1", "replace").lower()
+        body = chunk[header_end + sep :]
+        if body.endswith(b"\r\n"):
+            body = body[:-2]
+        elif body.endswith(b"\n"):
+            body = body[:-1]
+        if "content-disposition:" in headers and "filename=" in headers:
+            bodies.append(body)
+    return bodies
+
+
+def write_scan_copy(spool_dir: str, data: bytes) -> str:
+    fd, path = tempfile.mkstemp(prefix="part-", dir=spool_dir)
+    try:
+        os.fchmod(fd, 0o640)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        os.unlink(path)
+        raise
+    return path
+
+
+def signature_age_seconds(db_dir: str, now: float | None = None) -> float:
+    newest = None
+    for name in SIGNATURE_FILES:
+        candidate = os.path.join(db_dir, name)
+        try:
+            mtime = os.path.getmtime(candidate)
+        except OSError:
+            continue
+        if newest is None or mtime > newest:
+            newest = mtime
+    if newest is None:
+        return -1.0
+    return max(0.0, (now if now is not None else time.time()) - newest)
+
+
+def render_metrics(metrics: Metrics, config: GatewayConfig) -> str:
+    clamd_up = 1 if clamd_ping(config.clamd_socket) else 0
+    age = signature_age_seconds(config.db_dir)
+    with metrics.lock:
+        scans = metrics.scans
+        infected = metrics.infected
+        duration_sum = metrics.scan_seconds_sum
+    lines = [
+        "# HELP clamav_scans_total Uploads submitted to clamd",
+        "# TYPE clamav_scans_total counter",
+        f"clamav_scans_total {scans}",
+        "# HELP clamav_infected_total Uploads that matched a signature",
+        "# TYPE clamav_infected_total counter",
+        f"clamav_infected_total {infected}",
+        "# HELP clamav_scan_duration_seconds Time spent in clamd SCAN/INSTREAM",
+        "# TYPE clamav_scan_duration_seconds summary",
+        f"clamav_scan_duration_seconds_sum {duration_sum:.6f}",
+        f"clamav_scan_duration_seconds_count {scans}",
+        "# HELP clamav_signature_age_seconds Age of the newest official CVD/CLD",
+        "# TYPE clamav_signature_age_seconds gauge",
+        f"clamav_signature_age_seconds {age:.0f}",
+        "# HELP clamav_clamd_up Whether clamd answered PING",
+        "# TYPE clamav_clamd_up gauge",
+        f"clamav_clamd_up {clamd_up}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _filter_request_headers(headers) -> list[tuple[str, str]]:
+    forwarded = []
+    for key, value in headers.items():
+        if key.lower() in HOP_BY_HOP:
+            continue
+        if key.lower() == "x-dhis2-upstream":
+            continue
+        forwarded.append((key, value))
+    return forwarded
+
+
+def _filter_response_headers(headers) -> list[tuple[str, str]]:
+    return [
+        (key, value)
+        for key, value in headers.items()
+        if key.lower() not in HOP_BY_HOP
+    ]
+
+
+def forward_request(
+    config: GatewayConfig,
+    method: str,
+    path: str,
+    headers,
+    body_path: str | None,
+) -> tuple[int, list[tuple[str, str]], bytes]:
+    upstream = parse_upstream_header(headers.get("X-DHIS2-Upstream"))
+    if not allowlisted(upstream, config.upstreams):
+        return 502, [("Content-Type", "application/json")], json.dumps(
+            {"error": "invalid_upstream"}
+        ).encode()
+
+    host, port_s = upstream.rsplit(":", 1)
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    port = int(port_s)
+    fwd_headers = _filter_request_headers(headers)
+    body_file = None
+    if body_path is not None:
+        size = os.path.getsize(body_path)
+        body_file = open(body_path, "rb")
+        fwd_headers = [
+            (key, value)
+            for key, value in fwd_headers
+            if key.lower() != "content-length"
+        ]
+        fwd_headers.append(("Content-Length", str(size)))
+
+    conn = http.client.HTTPConnection(host, port, timeout=config.forward_timeout)
+    try:
+        conn.request(method, path, body=body_file, headers=dict(fwd_headers))
+        response = conn.getresponse()
+        payload = response.read()
+        return response.status, _filter_response_headers(response.headers), payload
+    finally:
+        if body_file is not None:
+            body_file.close()
+        conn.close()
+
+
+def make_handler(config: GatewayConfig, metrics: Metrics):
+    class GatewayHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, fmt: str, *args) -> None:
+            sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+        def _write(self, status: int, headers: list[tuple[str, str]], body: bytes) -> None:
+            self.send_response(status)
+            has_length = False
+            for key, value in headers:
+                if key.lower() == "content-length":
+                    has_length = True
+                self.send_header(key, value)
+            if not has_length:
+                self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+
+        def _json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self._write(status, [("Content-Type", "application/json")], body)
+
+        def _full_path(self) -> str:
+            return self.path
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.split("?", 1)[0] == "/healthz":
+                if clamd_ping(config.clamd_socket):
+                    self._write(200, [("Content-Type", "text/plain")], b"ok\n")
+                else:
+                    self._json(503, {"error": "scanner_unavailable"})
+                return
+            if self.path.split("?", 1)[0] == "/metrics":
+                body = render_metrics(metrics, config).encode()
+                self._write(200, [("Content-Type", "text/plain; version=0.0.4")], body)
+                return
+            self._proxy(scan=False)
+
+        def do_HEAD(self) -> None:  # noqa: N802
+            self._proxy(scan=False)
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._proxy(scan=True)
+
+        def do_PUT(self) -> None:  # noqa: N802
+            self._proxy(scan=True)
+
+        def do_DELETE(self) -> None:  # noqa: N802
+            self._proxy(scan=False)
+
+        def do_OPTIONS(self) -> None:  # noqa: N802
+            self._proxy(scan=False)
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            self._proxy(scan=False)
+
+        def _spool_body(self) -> str | None:
+            length_s = self.headers.get("Content-Length")
+            if length_s is None:
+                return None
+            try:
+                length = int(length_s)
+            except ValueError as exc:
+                raise ValueError("invalid_content_length") from exc
+            if length < 0:
+                raise ValueError("invalid_content_length")
+            if length > config.max_body:
+                raise ValueError("body_too_large")
+            fd, path = tempfile.mkstemp(prefix="scan-", dir=config.spool_dir)
+            try:
+                os.fchmod(fd, 0o640)
+                with os.fdopen(fd, "wb") as handle:
+                    leftover = copy_limited(self.rfile, handle, length)
+            except Exception:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                os.unlink(path)
+                raise
+            if leftover:
+                os.unlink(path)
+                raise ValueError("incomplete_body")
+            return path
+
+        def _proxy(self, scan: bool) -> None:
+            method = self.command
+            should_scan = scan and method in SCAN_METHODS
+            spool = None
+            part_paths: list[str] = []
+            try:
+                if should_scan or (self.headers.get("Content-Length") and method in SCAN_METHODS):
+                    try:
+                        spool = self._spool_body()
+                    except ValueError as exc:
+                        if str(exc) == "body_too_large":
+                            self._json(413, {"error": "body_too_large"})
+                        else:
+                            self._json(400, {"error": str(exc)})
+                        return
+                if should_scan:
+                    if spool is None:
+                        self._json(400, {"error": "missing_body"})
+                        return
+                    with open(spool, "rb") as handle:
+                        spool_bytes = handle.read()
+                    parts = multipart_filename_bodies(
+                        spool_bytes, self.headers.get("Content-Type")
+                    )
+                    scan_paths = [spool]
+                    if parts:
+                        part_paths = [
+                            write_scan_copy(config.spool_dir, part) for part in parts
+                        ]
+                        scan_paths = part_paths
+                    started = time.monotonic()
+                    try:
+                        for scan_path in scan_paths:
+                            scan_spool(
+                                config.clamd_socket, scan_path, config.scan_timeout
+                            )
+                    except Infected as exc:
+                        metrics.record_scan(time.monotonic() - started, True)
+                        self._json(
+                            403,
+                            {"error": "malware_detected", "signature": exc.signature},
+                        )
+                        return
+                    except (ScannerDown, OSError, TimeoutError):
+                        metrics.record_scan(time.monotonic() - started, False)
+                        if config.fail_open:
+                            pass
+                        else:
+                            self._json(503, {"error": "scanner_unavailable"})
+                            return
+                    else:
+                        metrics.record_scan(time.monotonic() - started, False)
+
+                status, headers, body = forward_request(
+                    config, method, self._full_path(), self.headers, spool
+                )
+                self._write(status, headers, body)
+            finally:
+                for part_path in part_paths:
+                    try:
+                        os.unlink(part_path)
+                    except OSError:
+                        pass
+                if spool is not None:
+                    try:
+                        os.unlink(spool)
+                    except OSError:
+                        pass
+
+    return GatewayHandler
+
+
+def serve(config: GatewayConfig | None = None) -> None:
+    cfg = config or config_from_env()
+    os.makedirs(cfg.spool_dir, exist_ok=True)
+    metrics = Metrics()
+    handler = make_handler(cfg, metrics)
+    server = ThreadingHTTPServer((cfg.listen_host, cfg.listen_port), handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    serve()

--- a/deploy/roles/clamav/files/test_clamav_gateway.py
+++ b/deploy/roles/clamav/files/test_clamav_gateway.py
@@ -1,0 +1,390 @@
+"""Gateway unit tests with a mock unix-socket clamd. No CVD download."""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.client import HTTPConnection
+from pathlib import Path
+
+_FILES_DIR = str(Path(__file__).resolve().parent)
+if _FILES_DIR not in sys.path:
+    sys.path.insert(0, _FILES_DIR)
+
+import clamav_gateway as gw  # noqa: E402
+
+EICAR = (
+    "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+)
+
+
+class MockClamd(threading.Thread):
+    def __init__(self, socket_path: str) -> None:
+        super().__init__(daemon=True)
+        self.socket_path = socket_path
+        self._stop = threading.Event()
+        self.down = False
+        self._server: socket.socket | None = None
+
+    def run(self) -> None:
+        if os.path.exists(self.socket_path):
+            os.unlink(self.socket_path)
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server = server
+        server.bind(self.socket_path)
+        server.listen(8)
+        server.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                conn, _ = server.accept()
+            except socket.timeout:
+                continue
+            with conn:
+                if self.down:
+                    continue
+                self._handle(conn)
+
+    def _handle(self, conn: socket.socket) -> None:
+        conn.settimeout(2)
+        header = b""
+        while not header.endswith(b"\n") and not header.endswith(b"\0"):
+            chunk = conn.recv(1)
+            if not chunk:
+                return
+            header += chunk
+        command = header.decode("utf-8", "replace").strip("\n\0")
+        if command.startswith("n") or command.startswith("z"):
+            command = command[1:]
+        if command == "PING":
+            conn.sendall(b"PONG\n")
+            return
+        if command.startswith("SCAN "):
+            path = command.split(" ", 1)[1]
+            payload = Path(path).read_bytes()
+            conn.sendall(self._verdict(path, payload))
+            return
+        if command == "INSTREAM":
+            data = bytearray()
+            while True:
+                size_raw = b""
+                while len(size_raw) < 4:
+                    piece = conn.recv(4 - len(size_raw))
+                    if not piece:
+                        return
+                    size_raw += piece
+                size = struct.unpack(">I", size_raw)[0]
+                if size == 0:
+                    break
+                remaining = size
+                while remaining:
+                    piece = conn.recv(min(8192, remaining))
+                    if not piece:
+                        return
+                    data.extend(piece)
+                    remaining -= len(piece)
+            conn.sendall(self._verdict("stream", bytes(data)))
+
+    def _verdict(self, label: str, payload: bytes) -> bytes:
+        # Match real clamd: EICAR is a whole-file signature, not a substring.
+        if payload == EICAR.encode():
+            return f"{label}: Eicar-Signature FOUND\n".encode()
+        return f"{label}: OK\n".encode()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._server is not None:
+            try:
+                self._server.close()
+            except OSError:
+                pass
+        if os.path.exists(self.socket_path):
+            os.unlink(self.socket_path)
+
+
+class MockUpstream(threading.Thread):
+    def __init__(self, host: str, port: int) -> None:
+        super().__init__(daemon=True)
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        self.requests: list[dict] = []
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, fmt: str, *args) -> None:
+                return
+
+            def _capture(self) -> None:
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                parent.requests.append(
+                    {
+                        "method": self.command,
+                        "path": self.path,
+                        "headers": {k.lower(): v for k, v in self.headers.items()},
+                        "body": body,
+                    }
+                )
+                payload = b'{"status":"ok"}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                if self.command != "HEAD":
+                    self.wfile.write(payload)
+
+            def do_GET(self) -> None:
+                self._capture()
+
+            def do_POST(self) -> None:
+                self._capture()
+
+            def do_PUT(self) -> None:
+                self._capture()
+
+        self.server = ThreadingHTTPServer((host, port), Handler)
+
+    def run(self) -> None:
+        self.server.serve_forever()
+
+    def stop(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+
+class GatewayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.spool = root / "spool"
+        self.spool.mkdir()
+        self.db_dir = root / "clamav"
+        self.db_dir.mkdir()
+        (self.db_dir / "daily.cvd").write_bytes(b"db")
+        os.utime(self.db_dir / "daily.cvd", (time.time() - 3600, time.time() - 3600))
+        self.clamd_sock = str(root / "clamd.ctl")
+        self.clamd = MockClamd(self.clamd_sock)
+        self.clamd.start()
+        self._wait_socket(self.clamd_sock)
+
+        self.upstream = MockUpstream("127.0.0.1", 0)
+        self.upstream.start()
+        self.upstream_port = self.upstream.server.server_address[1]
+
+        self.config = gw.GatewayConfig(
+            listen_host="127.0.0.1",
+            listen_port=0,
+            clamd_socket=self.clamd_sock,
+            spool_dir=str(self.spool),
+            fail_open=False,
+            upstreams=frozenset({f"127.0.0.1:{self.upstream_port}"}),
+            max_body=1024 * 1024,
+            db_dir=str(self.db_dir),
+            scan_timeout=5.0,
+            forward_timeout=5.0,
+        )
+        self.metrics = gw.Metrics()
+        handler = gw.make_handler(self.config, self.metrics)
+        from http.server import ThreadingHTTPServer
+
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+        self.gw_port = self.httpd.server_address[1]
+
+    def tearDown(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.upstream.stop()
+        self.clamd.stop()
+        self.tmp.cleanup()
+
+    def _wait_socket(self, path: str) -> None:
+        for _ in range(50):
+            if os.path.exists(path):
+                return
+            time.sleep(0.05)
+        self.fail(f"mock clamd socket missing: {path}")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        upstream: str | None = "auto",
+        extra_headers: dict | None = None,
+    ):
+        headers = {"Host": "dhis.example.org"}
+        if upstream == "auto":
+            headers["X-DHIS2-Upstream"] = f"http://127.0.0.1:{self.upstream_port}"
+        elif upstream:
+            headers["X-DHIS2-Upstream"] = upstream
+        if extra_headers:
+            headers.update(extra_headers)
+        conn = HTTPConnection("127.0.0.1", self.gw_port, timeout=5)
+        try:
+            conn.request(method, path, body=body, headers=headers)
+            response = conn.getresponse()
+            return response.status, response.read(), dict(response.getheaders())
+        finally:
+            conn.close()
+
+    def test_eicar_is_blocked_and_not_forwarded(self) -> None:
+        status, body, _ = self._request(
+            "POST", "/api/fileResources", body=EICAR.encode()
+        )
+        self.assertEqual(status, 403)
+        self.assertIn(b"malware_detected", body)
+        self.assertIn(b"Eicar-Signature", body)
+        self.assertEqual(self.upstream.requests, [])
+
+    def test_clean_post_is_forwarded_unchanged(self) -> None:
+        payload = b"clean-upload-bytes"
+        status, body, _ = self._request("POST", "/api/fileResources", body=payload)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b'{"status":"ok"}')
+        self.assertEqual(len(self.upstream.requests), 1)
+        seen = self.upstream.requests[0]
+        self.assertEqual(seen["method"], "POST")
+        self.assertEqual(seen["path"], "/api/fileResources")
+        self.assertEqual(seen["body"], payload)
+        self.assertEqual(seen["headers"]["host"], "dhis.example.org")
+
+    def test_get_is_not_scanned(self) -> None:
+        status, _, _ = self._request("GET", "/api/fileResources")
+        self.assertEqual(status, 200)
+        self.assertEqual(self.upstream.requests[0]["method"], "GET")
+        self.assertEqual(self.metrics.scans, 0)
+
+    def test_missing_upstream_is_502(self) -> None:
+        status, body, _ = self._request(
+            "GET", "/api/fileResources", upstream=None
+        )
+        self.assertEqual(status, 502)
+        self.assertIn(b"invalid_upstream", body)
+        self.assertEqual(self.upstream.requests, [])
+
+    def test_unknown_upstream_is_502(self) -> None:
+        status, body, _ = self._request(
+            "POST",
+            "/api/fileResources",
+            body=b"x",
+            upstream="http://10.1.2.3:8080",
+        )
+        self.assertEqual(status, 502)
+        self.assertIn(b"invalid_upstream", body)
+        self.assertEqual(self.upstream.requests, [])
+
+    def test_clamd_down_fail_closed(self) -> None:
+        self.clamd.down = True
+        os.unlink(self.clamd_sock)
+        status, body, _ = self._request("POST", "/api/fileResources", body=b"x")
+        self.assertEqual(status, 503)
+        self.assertIn(b"scanner_unavailable", body)
+        self.assertEqual(self.upstream.requests, [])
+
+    def test_clamd_down_fail_open_forwards(self) -> None:
+        self.config.fail_open = True
+        self.clamd.down = True
+        os.unlink(self.clamd_sock)
+        status, _, _ = self._request("POST", "/api/fileResources", body=b"x")
+        self.assertEqual(status, 200)
+        self.assertEqual(self.upstream.requests[0]["body"], b"x")
+
+    def test_healthz_ping_only(self) -> None:
+        status, body, _ = self._request("GET", "/healthz", upstream=None)
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"ok\n")
+
+    def test_healthz_down(self) -> None:
+        self.clamd.down = True
+        os.unlink(self.clamd_sock)
+        status, body, _ = self._request("GET", "/healthz", upstream=None)
+        self.assertEqual(status, 503)
+        self.assertIn(b"scanner_unavailable", body)
+
+    def test_metrics_include_signature_age_and_clamd(self) -> None:
+        self._request("POST", "/api/fileResources", body=b"ok")
+        status, body, _ = self._request("GET", "/metrics", upstream=None)
+        self.assertEqual(status, 200)
+        text = body.decode()
+        self.assertIn("clamav_scans_total 1", text)
+        self.assertIn("clamav_infected_total 0", text)
+        self.assertIn("clamav_clamd_up 1", text)
+        self.assertIn("clamav_signature_age_seconds", text)
+        age = int(
+            [line for line in text.splitlines() if line.startswith("clamav_signature_age_seconds ")][0].split()[1]
+        )
+        self.assertGreaterEqual(age, 1)
+
+    def test_copy_limited_reports_short_read(self) -> None:
+        import io
+
+        dest = io.BytesIO()
+        leftover = gw.copy_limited(io.BytesIO(b"ab"), dest, 10)
+        self.assertEqual(leftover, 8)
+        self.assertEqual(dest.getvalue(), b"ab")
+
+    def test_invalid_content_length_is_400(self) -> None:
+        status, body, _ = self._request(
+            "POST",
+            "/api/fileResources",
+            body=b"x",
+            extra_headers={"Content-Length": "nope"},
+        )
+        self.assertEqual(status, 400)
+        self.assertIn(b"invalid_content_length", body)
+        self.assertEqual(self.upstream.requests, [])
+
+    def _multipart(self, filename: str, payload: bytes) -> tuple[bytes, str]:
+        boundary = "----GatewayTestBoundary"
+        body = (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+            "Content-Type: application/octet-stream\r\n"
+            "\r\n"
+        ).encode() + payload + f"\r\n--{boundary}--\r\n".encode()
+        return body, f"multipart/form-data; boundary={boundary}"
+
+    def test_multipart_eicar_is_blocked_and_not_forwarded(self) -> None:
+        body, content_type = self._multipart("eicar.com", EICAR.encode())
+        status, resp, _ = self._request(
+            "POST",
+            "/api/fileResources",
+            body=body,
+            extra_headers={"Content-Type": content_type},
+        )
+        self.assertEqual(status, 403)
+        self.assertIn(b"malware_detected", resp)
+        self.assertEqual(self.upstream.requests, [])
+
+    def test_multipart_clean_is_forwarded_unchanged(self) -> None:
+        payload = b"clean-upload-bytes"
+        body, content_type = self._multipart("clean.txt", payload)
+        status, _, _ = self._request(
+            "POST",
+            "/api/fileResources",
+            body=body,
+            extra_headers={"Content-Type": content_type},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(len(self.upstream.requests), 1)
+        self.assertEqual(self.upstream.requests[0]["body"], body)
+
+    def test_parse_upstream_header(self) -> None:
+        self.assertEqual(gw.parse_upstream_header("http://10.0.0.4:8080"), "10.0.0.4:8080")
+        self.assertEqual(gw.parse_upstream_header("10.0.0.4:8080"), "10.0.0.4:8080")
+        self.assertEqual(
+            gw.parse_upstream_header("http://[2001:db8::1]:8080"), "[2001:db8::1]:8080"
+        )
+        self.assertIsNone(gw.parse_upstream_header(""))
+        self.assertIsNone(gw.parse_upstream_header(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/roles/clamav/handlers/main.yml
+++ b/deploy/roles/clamav/handlers/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Reload clamd AppArmor
+  ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/usr.sbin.clamd
+  changed_when: true
+  when:
+    - clamav_apparmor_profile is defined
+    - clamav_apparmor_profile.stat.exists
+
+- name: Restart clamav-daemon
+  ansible.builtin.systemd:
+    name: clamav-daemon
+    state: restarted
+    enabled: true
+    daemon_reload: true
+
+- name: Restart clamav-freshclam
+  ansible.builtin.systemd:
+    name: clamav-freshclam
+    state: restarted
+    enabled: true
+
+- name: Restart clamav-gateway
+  ansible.builtin.systemd:
+    name: clamav-gateway
+    state: restarted
+    enabled: true
+    daemon_reload: true

--- a/deploy/roles/clamav/meta/argument_specs.yml
+++ b/deploy/roles/clamav/meta/argument_specs.yml
@@ -1,0 +1,30 @@
+---
+argument_specs:
+  main:
+    short_description: Opt-in ClamAV upload scanning at the reverse proxy
+    options:
+      clamav_enabled:
+        description: Master gate for the scanner host and proxy intercepts
+        type: bool
+        default: false
+      clamav_fail_open:
+        description: Break-glass — forward uploads if clamd is down
+        type: bool
+        default: false
+      clamav_scan_app_zips:
+        description: Intercept POST /api/apps
+        type: bool
+        default: true
+      clamav_scan_ui_assets:
+        description: Intercept custom JS/CSS and logo uploads
+        type: bool
+        default: true
+      clamav_gateway_port:
+        description: Bridge listen port for the scan-and-forward gateway
+        type: int
+        default: 8081
+      clamav_private_mirror:
+        description: >-
+          Air-gapped freshclam mirror (empty uses database.clamav.net)
+        type: str
+        required: false

--- a/deploy/roles/clamav/meta/main.yml
+++ b/deploy/roles/clamav/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: clamav
+  author: dhis2
+  description: Opt-in ClamAV upload scanner and scan-and-forward gateway
+  license: BSD-2-Clause
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Ubuntu
+      versions: [jammy, noble]
+  galaxy_tags: [dhis2, clamav, antivirus]
+dependencies: []

--- a/deploy/roles/clamav/tasks/install.yml
+++ b/deploy/roles/clamav/tasks/install.yml
@@ -1,0 +1,205 @@
+---
+- name: ClamAV | Install scanner packages
+  ansible.builtin.apt:
+    name:
+      - clamav-daemon
+      - clamav-freshclam
+      - python3
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Create gateway system user
+  ansible.builtin.user:
+    name: "{{ clamav_gateway_user }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: /nonexistent
+    create_home: false
+    groups: clamav
+    append: true
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Create gateway spool directory
+  ansible.builtin.file:
+    path: "{{ clamav_spool_dir }}"
+    state: directory
+    owner: "{{ clamav_gateway_user }}"
+    group: clamav
+    mode: "2770"
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Deploy clamd.conf
+  ansible.builtin.template:
+    src: clamd.conf.j2
+    dest: /etc/clamav/clamd.conf
+    owner: root
+    group: clamav
+    mode: "0640"
+  notify: Restart clamav-daemon
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Deploy freshclam.conf
+  ansible.builtin.template:
+    src: freshclam.conf.j2
+    dest: /etc/clamav/freshclam.conf
+    owner: root
+    group: clamav
+    mode: "0640"
+  notify: Restart clamav-freshclam
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Check for clamd AppArmor profile
+  ansible.builtin.stat:
+    path: /etc/apparmor.d/usr.sbin.clamd
+  register: clamav_apparmor_profile
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Allow clamd to SCAN the gateway spool
+  ansible.builtin.template:
+    src: usr.sbin.clamd.local.j2
+    dest: /etc/apparmor.d/local/usr.sbin.clamd
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload clamd AppArmor
+    - Restart clamav-daemon
+  when: clamav_apparmor_profile.stat.exists
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Check whether official signature databases exist
+  ansible.builtin.shell: |
+    set -o pipefail
+    for name in main daily bytecode; do
+      if [ ! -f "{{ clamav_db_dir }}/${name}.cvd" ] && [ ! -f "{{ clamav_db_dir }}/${name}.cld" ]; then
+        exit 1
+      fi
+    done
+  args:
+    executable: /bin/bash
+  register: clamav_cvd_present
+  changed_when: false
+  failed_when: false
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Stop clamd until signature databases exist
+  ansible.builtin.systemd:
+    name: clamav-daemon
+    state: stopped
+  when: clamav_cvd_present.rc != 0
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Start freshclam
+  ansible.builtin.systemd:
+    name: clamav-freshclam
+    state: started
+    enabled: true
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Wait for official signature databases
+  ansible.builtin.shell: |
+    set -o pipefail
+    for name in main daily bytecode; do
+      if [ ! -f "{{ clamav_db_dir }}/${name}.cvd" ] && [ ! -f "{{ clamav_db_dir }}/${name}.cld" ]; then
+        exit 1
+      fi
+    done
+  args:
+    executable: /bin/bash
+  register: clamav_cvd_wait
+  retries: 60
+  delay: 10
+  until: clamav_cvd_wait.rc == 0
+  changed_when: false
+  when: clamav_cvd_present.rc != 0
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Start clamd
+  ansible.builtin.systemd:
+    name: clamav-daemon
+    state: started
+    enabled: true
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Deploy gateway script
+  ansible.builtin.copy:
+    src: clamav_gateway.py
+    dest: /usr/local/lib/clamav-gateway.py
+    owner: root
+    # Group=clamav in the unit; 0750 root:clamav-gateway is unreadable to that gid.
+    group: clamav
+    mode: "0750"
+  notify: Restart clamav-gateway
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Deploy gateway environment
+  ansible.builtin.template:
+    src: clamav-gateway.default.j2
+    dest: /etc/default/clamav-gateway
+    owner: root
+    group: "{{ clamav_gateway_user }}"
+    mode: "0640"
+  notify: Restart clamav-gateway
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Deploy gateway systemd unit
+  ansible.builtin.template:
+    src: clamav-gateway.service.j2
+    dest: /etc/systemd/system/clamav-gateway.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart clamav-gateway
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Flush handlers before enabling gateway
+  ansible.builtin.meta: flush_handlers
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Enable and start gateway
+  ansible.builtin.systemd:
+    name: clamav-gateway
+    state: started
+    enabled: true
+    daemon_reload: true
+  tags: [clamav, clamav-install, install]
+
+- name: ClamAV | Allow gateway port from the reverse proxy
+  community.general.ufw:
+    rule: allow
+    port: "{{ clamav_gateway_port }}"
+    src: "{{ hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']) }}"
+    proto: tcp
+    comment: Upload scan from the reverse proxy
+    state: enabled
+  loop: "{{ groups['web'] | default([]) }}"
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Allow gateway metrics from monitoring
+  community.general.ufw:
+    rule: allow
+    port: "{{ clamav_gateway_port }}"
+    src: "{{ hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']) }}"
+    proto: tcp
+    comment: Gateway metrics from monitoring
+    state: enabled
+  loop: "{{ groups['monitoring'] | default([]) }}"
+  when: >
+    server_monitoring is defined
+    and server_monitoring in ['grafana', 'prometheus', 'grafana/prometheus']
+  tags: [clamav, clamav-configure, configure]
+
+- name: ClamAV | Allow Tomcat from the scanner
+  community.general.ufw:
+    rule: allow
+    port: "{{ hostvars[item]['tomcat_port'] | default('8080') }}"
+    src: "{{ hostvars[groups['clamav_servers'][0]]['service_ip']
+       | default(hostvars[groups['clamav_servers'][0]]['ansible_host']) }}"
+    proto: tcp
+    comment: tomcat access from the upload scanner
+    state: enabled
+  loop: "{{ groups['instances'] | default([]) }}"
+  delegate_to: "{{ item }}"
+  tags: [clamav, clamav-configure, configure]

--- a/deploy/roles/clamav/tasks/lxd.yml
+++ b/deploy/roles/clamav/tasks/lxd.yml
@@ -1,0 +1,66 @@
+---
+- name: ClamAV | Create scanner container
+  become: true
+  vars:
+    ansible_connection: local
+  community.general.lxd_container:
+    config:
+      boot.autostart.priority: "5"
+      limits.memory: "{{ clamav_lxd_memory }}"
+      user.type: "{{ group_names[0] }}"
+    name: "{{ inventory_hostname }}"
+    state: started
+    profiles: [default]
+    ignore_volatile_options: false
+    wait_for_ipv4_addresses: true
+    timeout: 600
+    source:
+      type: image
+      mode: pull
+      server: "{{ lxd_source_server | default('https://cloud-images.ubuntu.com/releases') }}"
+      protocol: "{{ lxd_source_protocol | default('simplestreams') }}"
+      alias: "{{ guest_os }}/{{ guest_os_arch | default('amd64') }}"
+    devices:
+      eth0:
+        nictype: bridged
+        parent: "{{ lxd_bridge_interface | default('lxdbr1') }}"
+        type: nic
+        ipv4.address: "{{ ansible_host | ansible.utils.ipaddr(lxd_network) }}"
+      root:
+        path: /
+        pool: "{{ lxd_storage_pool_name | default('default') }}"
+        type: disk
+  register: clamav_create_lxd_container_status
+
+- name: ClamAV | Gather network facts
+  ansible.builtin.setup:
+    gather_subset:
+      - network
+      - "!min"
+
+- name: ClamAV | Ensure container has configured static IP
+  become: true
+  vars:
+    ansible_connection: local
+  community.general.lxd_container:
+    name: "{{ inventory_hostname }}"
+    state: restarted
+    wait_for_ipv4_addresses: true
+  when:
+    - ansible_host != ansible_facts['default_ipv4']['address']
+  register: clamav_restart_lxd_container_status
+
+- name: ClamAV | Wait for systemd to be ready
+  ansible.builtin.wait_for:
+    path: /run/systemd/system
+    state: present
+    timeout: 10
+  become: true
+  when: clamav_create_lxd_container_status.changed or clamav_restart_lxd_container_status.changed
+
+- name: ClamAV | Ensure timezone is {{ timezone }}
+  community.general.timezone:
+    name: "{{ timezone }}"
+
+- name: ClamAV | Install and configure scanner
+  ansible.builtin.include_tasks: install.yml

--- a/deploy/roles/clamav/tasks/main.yml
+++ b/deploy/roles/clamav/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: ClamAV | Pre-flight RAM and group checks
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+    apply:
+      tags: [always]
+  tags: [always]
+  when: clamav_enabled | default(false) | bool
+  run_once: true
+
+- name: ClamAV | Include connection-specific tasks
+  ansible.builtin.include_tasks:
+    file: "{{ ansible_connection }}.yml"
+    apply:
+      tags: [clamav, clamav-install, install]
+  tags: [clamav, clamav-install, install]
+  when:
+    - clamav_enabled | default(false) | bool
+    - inventory_hostname in groups['clamav_servers'] | default([])

--- a/deploy/roles/clamav/tasks/preflight.yml
+++ b/deploy/roles/clamav/tasks/preflight.yml
@@ -1,0 +1,51 @@
+---
+- name: ClamAV | Assert [clamav_servers] has a host
+  ansible.builtin.assert:
+    that:
+      - groups['clamav_servers'] | default([]) | length > 0
+    fail_msg: >-
+      clamav_enabled is true but [clamav_servers] is empty.
+      Add a clamav host to inventory, or set clamav_enabled=false.
+    quiet: true
+  tags: [always]
+
+- name: ClamAV | Resolve whether the scanner is an LXD container
+  ansible.builtin.set_fact:
+    clamav_mem_is_lxd: >-
+      {{ (hostvars[groups['clamav_servers'][0]]['ansible_connection']
+          | default(ansible_connection)) == 'lxd' }}
+  tags: [always]
+
+- name: ClamAV | Read MemAvailable on the LXD hypervisor
+  ansible.builtin.command: awk '/^MemAvailable:/ {print $2}' /proc/meminfo
+  register: clamav_mem_available_kb
+  changed_when: false
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  become: true
+  when: clamav_mem_is_lxd | bool
+  tags: [always]
+
+- name: ClamAV | Read MemAvailable on the scanner VM
+  ansible.builtin.command: awk '/^MemAvailable:/ {print $2}' /proc/meminfo
+  register: clamav_mem_available_kb
+  changed_when: false
+  delegate_to: "{{ groups['clamav_servers'][0] }}"
+  become: true
+  when: not (clamav_mem_is_lxd | bool)
+  tags: [always]
+
+- name: ClamAV | Assert host has at least 4 GiB MemAvailable
+  ansible.builtin.assert:
+    that:
+      - (clamav_mem_available_kb.stdout | trim | int) >= (clamav_min_host_mem_available_kb | int)
+    fail_msg: >-
+      clamav_enabled requires at least 4 GiB MemAvailable on
+      {{ 'the LXD hypervisor' if (clamav_mem_is_lxd | bool) else groups['clamav_servers'][0] }}
+      before the scanner is created
+      (LXD hypervisor, or the clamav VM in SSH mode).
+      This host has {{ ((clamav_mem_available_kb.stdout | trim | int) / 1024) | round(0, 'floor') | int }} MiB
+      available. Add RAM, then re-run, or set clamav_enabled=false.
+    quiet: true
+  tags: [always]

--- a/deploy/roles/clamav/tasks/ssh.yml
+++ b/deploy/roles/clamav/tasks/ssh.yml
@@ -1,0 +1,28 @@
+---
+- name: ClamAV | Gather host facts
+  ansible.builtin.setup:
+    gather_subset:
+      - network
+      - "!min"
+
+- name: ClamAV | Install acl
+  ansible.builtin.apt:
+    name: acl
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: ClamAV | Allow SSH on the scanner VM
+  community.general.ufw:
+    rule: limit
+    port: "{{ ansible_port | default('22') }}"
+    src: 0.0.0.0/0
+    proto: tcp
+    comment: Allow ssh access to the scanner
+
+- name: ClamAV | Ensure timezone is {{ timezone }}
+  community.general.timezone:
+    name: "{{ timezone }}"
+
+- name: ClamAV | Install and configure scanner
+  ansible.builtin.include_tasks: install.yml

--- a/deploy/roles/clamav/templates/clamav-gateway.default.j2
+++ b/deploy/roles/clamav/templates/clamav-gateway.default.j2
@@ -1,0 +1,17 @@
+{{ ansible_managed | comment }}
+CLAMAV_LISTEN_HOST=0.0.0.0
+CLAMAV_LISTEN_PORT={{ clamav_gateway_port }}
+CLAMAV_SOCKET={{ clamav_socket }}
+CLAMAV_SPOOL_DIR={{ clamav_spool_dir }}
+CLAMAV_FAIL_OPEN={{ clamav_fail_open | bool | lower }}
+{% set ns = namespace(upstreams=[]) %}
+{% for inst in groups['instances'] | default([]) %}
+{% set ns.upstreams = ns.upstreams + [
+  (hostvars[inst]['service_ip'] | default(hostvars[inst]['ansible_host']))
+  | hostport(tomcat_port | default('8080'))
+] %}
+{% endfor %}
+
+CLAMAV_UPSTREAMS={{ ns.upstreams | join(',') }}
+CLAMAV_MAX_BODY={{ clamav_max_body_bytes }}
+CLAMAV_DB_DIR={{ clamav_db_dir }}

--- a/deploy/roles/clamav/templates/clamav-gateway.service.j2
+++ b/deploy/roles/clamav/templates/clamav-gateway.service.j2
@@ -1,0 +1,36 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=DHIS2 ClamAV upload scan gateway
+Wants=network-online.target clamav-daemon.service
+After=network-online.target clamav-daemon.service
+
+[Service]
+User={{ clamav_gateway_user }}
+Group=clamav
+Type=simple
+EnvironmentFile=/etc/default/clamav-gateway
+ExecStart=/usr/bin/python3 /usr/local/lib/clamav-gateway.py
+Restart=on-failure
+RestartSec=5
+MemoryMax=1G
+TasksMax=32
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ReadWritePaths={{ clamav_spool_dir }}
+ReadOnlyPaths={{ clamav_db_dir }}
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+CapabilityBoundingSet=
+AmbientCapabilities=
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/roles/clamav/templates/clamd.conf.j2
+++ b/deploy/roles/clamav/templates/clamd.conf.j2
@@ -1,0 +1,25 @@
+{{ ansible_managed | comment }}
+LocalSocket {{ clamav_socket }}
+FixStaleSocket true
+LocalSocketGroup clamav
+LocalSocketMode 660
+User clamav
+DatabaseDirectory {{ clamav_db_dir }}
+TemporaryDirectory /tmp
+PidFile /run/clamav/clamd.pid
+LogFile /var/log/clamav/clamav.log
+LogTime true
+LogRotate true
+Foreground false
+ScanMail false
+ScanArchive true
+AlertEncrypted false
+OfficialDatabaseOnly yes
+ConcurrentDatabaseReload no
+StreamMaxLength {{ clamav_stream_max_length }}
+MaxFileSize {{ clamav_max_file_size }}
+MaxScanSize {{ clamav_max_scan_size }}
+MaxScanTime {{ clamav_max_scan_time }}
+MaxFiles {{ clamav_max_files }}
+MaxRecursion {{ clamav_max_recursion }}
+MaxDirectoryRecursion {{ clamav_max_recursion }}

--- a/deploy/roles/clamav/templates/freshclam.conf.j2
+++ b/deploy/roles/clamav/templates/freshclam.conf.j2
@@ -1,0 +1,17 @@
+{{ ansible_managed | comment }}
+DatabaseOwner clamav
+UpdateLogFile /var/log/clamav/freshclam.log
+LogTime true
+LogRotate true
+DatabaseDirectory {{ clamav_db_dir }}
+{% if clamav_private_mirror | default('') | length > 0 %}
+PrivateMirror {{ clamav_private_mirror }}
+{% else %}
+DatabaseMirror database.clamav.net
+{% endif %}
+Checks 24
+ScriptedUpdates yes
+NotifyClamd /etc/clamav/clamd.conf
+# Load-testing a new CVD in freshclam roughly doubles RAM; skip it under the 4 GiB cap.
+TestDatabases no
+Foreground false

--- a/deploy/roles/clamav/templates/usr.sbin.clamd.local.j2
+++ b/deploy/roles/clamav/templates/usr.sbin.clamd.local.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+# clamd SCAN of the gateway spool (unix-socket SCAN, not INSTREAM)
+{{ clamav_spool_dir }}/ r,
+{{ clamav_spool_dir }}/** r,

--- a/deploy/roles/create-instance/tasks/main.yml
+++ b/deploy/roles/create-instance/tasks/main.yml
@@ -89,3 +89,29 @@
     - server_monitoring is defined and server_monitoring in ['grafana', 'prometheus', 'grafana/prometheus']
     - groups['monitoring']  | length > 0
     - inventory_hostname in groups['instances']
+
+- name: ClamAV | Refresh gateway upstream allowlist
+  ansible.builtin.template:
+    src: "{{ playbook_dir }}/roles/clamav/templates/clamav-gateway.default.j2"
+    dest: /etc/default/clamav-gateway
+    owner: root
+    group: "{{ clamav_gateway_user | default('clamav-gateway') }}"
+    mode: "0640"
+  delegate_to: "{{ groups['clamav_servers'][0] }}"
+  run_once: true
+  register: clamav_gateway_env
+  when:
+    - clamav_enabled | default(false) | bool
+    - groups['clamav_servers'] | default([]) | length > 0
+
+- name: ClamAV | Restart gateway after allowlist change
+  ansible.builtin.systemd:
+    name: clamav-gateway
+    state: restarted
+  delegate_to: "{{ groups['clamav_servers'][0] }}"
+  run_once: true
+  when:
+    - clamav_enabled | default(false) | bool
+    - groups['clamav_servers'] | default([]) | length > 0
+    - clamav_gateway_env is defined
+    - clamav_gateway_env is changed

--- a/deploy/roles/create-instance/tasks/proxy/nginx.yml
+++ b/deploy/roles/create-instance/tasks/proxy/nginx.yml
@@ -16,6 +16,14 @@
     nginx_version: "0"
   when: nginx_version_output.rc != 0
 
+- name: Ensure nginx security_headers.conf exists
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/roles/proxy/files/security_headers.conf"
+    dest: /etc/nginx/security_headers.conf
+    owner: root
+    group: root
+    mode: "0640"
+
 # consider creating custom filter for this task.
 # Rigt now, it does not work when fqdn is not defined
 - name: Assert two instances using the same fqdn have unique Instance Names
@@ -65,7 +73,7 @@
     paths: /etc/nginx/conf.d/
     patterns: '*'
     file_type: file
-    excludes: "{{ groups['instances'] | map('extract', hostvars, 'fqdn') | map('default', 'default', true) | map('regex_replace', '^\\s+|\\s+$', '') | unique | map('regex_replace', '^$', 'default') | map('regex_replace', '(.+)', '\\1.conf') | list }}"
+    excludes: "{{ (groups['instances'] | map('extract', hostvars, 'fqdn') | map('default', 'default', true) | map('regex_replace', '^\\s+|\\s+$', '') | unique | map('regex_replace', '^$', 'default') | map('regex_replace', '(.+)', '\\1.conf') | list) + ['clamav_upstream.conf'] }}"
   register: found_files
 
 - name: Clean /etc/nginx/conf.d/ directory
@@ -73,6 +81,27 @@
     path: "{{ item }}"
     state: absent
   loop: "{{ found_files['files'] | map(attribute='path') }}"
+
+- name: ClamAV | Deploy nginx gateway upstream
+  ansible.builtin.template:
+    src: clamav/nginx_upstream.j2
+    dest: /etc/nginx/conf.d/clamav_upstream.conf
+    owner: root
+    group: root
+    mode: "0640"
+  notify: Reload Nginx
+  when:
+    - clamav_enabled | default(false) | bool
+    - groups['clamav_servers'] | default([]) | length > 0
+
+- name: ClamAV | Remove nginx gateway upstream
+  ansible.builtin.file:
+    path: /etc/nginx/conf.d/clamav_upstream.conf
+    state: absent
+  notify: Reload Nginx
+  when: >
+    not (clamav_enabled | default(false) | bool)
+    or (groups['clamav_servers'] | default([]) | length == 0)
 
 - name: Copy static Nginx config for valid FQDNs
   ansible.builtin.copy:

--- a/deploy/roles/create-instance/tasks/proxy/openresty.yml
+++ b/deploy/roles/create-instance/tasks/proxy/openresty.yml
@@ -18,6 +18,14 @@
     nginx_version: "0"
   when: openresty_version_output.rc != 0
 
+- name: Ensure OpenResty security_headers.conf exists
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/roles/proxy/files/security_headers.conf"
+    dest: /usr/local/openresty/nginx/conf/security_headers.conf
+    owner: root
+    group: root
+    mode: "0640"
+
 - name: Assert two instances using the same fqdn have unique Instance Names
   ansible.builtin.assert:
     that:
@@ -64,7 +72,7 @@
     paths: /usr/local/openresty/nginx/conf/conf.d/
     patterns: '*'
     file_type: file
-    excludes: "{{ groups['instances'] | map('extract', hostvars, 'fqdn') | map('default', 'default', true) | map('regex_replace', '^\\s+|\\s+$', '') | unique | map('regex_replace', '^$', 'default') | map('regex_replace', '(.+)', '\\1.conf') | list }}"
+    excludes: "{{ (groups['instances'] | map('extract', hostvars, 'fqdn') | map('default', 'default', true) | map('regex_replace', '^\\s+|\\s+$', '') | unique | map('regex_replace', '^$', 'default') | map('regex_replace', '(.+)', '\\1.conf') | list) + ['clamav_upstream.conf'] }}"
   register: found_files
 
 - name: Clean /usr/local/openresty/nginx/conf/conf.d/ directory
@@ -72,6 +80,27 @@
     path: "{{ item }}"
     state: absent
   loop: "{{ found_files['files'] | map(attribute='path') }}"
+
+- name: ClamAV | Deploy OpenResty gateway upstream
+  ansible.builtin.template:
+    src: clamav/nginx_upstream.j2
+    dest: /usr/local/openresty/nginx/conf/conf.d/clamav_upstream.conf
+    owner: root
+    group: root
+    mode: "0640"
+  notify: Reload Openresty
+  when:
+    - clamav_enabled | default(false) | bool
+    - groups['clamav_servers'] | default([]) | length > 0
+
+- name: ClamAV | Remove OpenResty gateway upstream
+  ansible.builtin.file:
+    path: /usr/local/openresty/nginx/conf/conf.d/clamav_upstream.conf
+    state: absent
+  notify: Reload Openresty
+  when: >
+    not (clamav_enabled | default(false) | bool)
+    or (groups['clamav_servers'] | default([]) | length == 0)
 
 - name: Copy static OpenResty config for valid FQDNs
   ansible.builtin.copy:

--- a/deploy/roles/create-instance/tasks/tomcat-setup.yml
+++ b/deploy/roles/create-instance/tasks/tomcat-setup.yml
@@ -129,3 +129,16 @@
   when: >
     app_monitoring is defined and
     app_monitoring == "glowroot"
+
+- name: Open port 8080 (tomcat) access from the upload scanner
+  community.general.ufw:
+    rule: allow
+    port: "{{ tomcat_port | default('8080') }}"
+    src: "{{ hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']) }}"
+    proto: tcp
+    state: enabled
+    comment: tomcat access from the upload scanner
+  loop: "{{ groups['clamav_servers'] | default([]) }}"
+  when:
+    - clamav_enabled | default(false) | bool
+    - groups['clamav_servers'] | default([]) | length > 0

--- a/deploy/roles/create-instance/templates/apache2/instance.j2
+++ b/deploy/roles/create-instance/templates/apache2/instance.j2
@@ -3,8 +3,8 @@
 {% if  hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string == "ROOT"  %}
 <Location />
     Require all granted
-    ProxyPass "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']))+':8080' }}/"
-    ProxyPassReverse "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']))+':8080'}}/"
+    ProxyPass "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host'])) | hostport(tomcat_port | default('8080')) }}/"
+    ProxyPassReverse "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host'])) | hostport(tomcat_port | default('8080')) }}/"
 </Location>
 
 {% if _glowroot_enabled and not _glowroot_locked %}
@@ -17,8 +17,8 @@
 {% else %}
 <Location /{{ hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string }}>
     Require all granted
-    ProxyPass "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']))+':8080' }}/{{ hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string }}"
-    ProxyPassReverse "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']))+':8080'}}/{{ hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string }}"
+    ProxyPass "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host'])) | hostport(tomcat_port | default('8080')) }}/{{ hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string }}"
+    ProxyPassReverse "http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host'])) | hostport(tomcat_port | default('8080')) }}/{{ hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string }}"
 </Location>
 
 {% if _glowroot_enabled and not _glowroot_locked %}
@@ -29,4 +29,7 @@
 </Location>
 {% endif %}
 {% endif %}
+{# Location / matches every URL; later LocationMatch sections merge last
+   and override ProxyPass for the upload paths. #}
+{% include 'clamav/apache_locations.j2' %}
 

--- a/deploy/roles/create-instance/templates/clamav/apache_locations.j2
+++ b/deploy/roles/create-instance/templates/clamav/apache_locations.j2
@@ -1,0 +1,37 @@
+{% set _clamav_on = (clamav_enabled | default(false) | bool)
+     and (groups['clamav_servers'] | default([]) | length > 0) %}
+{% if _clamav_on %}
+{% set _base = '' if (hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string == 'ROOT')
+     else '/' ~ (hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string) %}
+{% set _gw = (hostvars[groups['clamav_servers'][0]]['service_ip']
+     | default(hostvars[groups['clamav_servers'][0]]['ansible_host']))
+     | hostport(clamav_gateway_port | default(8081)) %}
+{% set _inst = (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host']))
+     | hostport(tomcat_port | default('8080')) %}
+{% set ns = namespace(patterns=[
+  _base ~ '/api(?:/[0-9]+)?/fileResources/?',
+  _base ~ '/api(?:/[0-9]+)?/dataValues/file/?',
+  _base ~ '/api(?:/[0-9]+)?/messageConversations/attachments/?',
+]) %}
+{% if clamav_scan_app_zips | default(true) | bool %}
+{% set ns.patterns = ns.patterns + [_base ~ '/api(?:/[0-9]+)?/apps/?'] %}
+{% endif %}
+{% if clamav_scan_ui_assets | default(true) | bool %}
+{% set ns.patterns = ns.patterns + [
+  _base ~ '/api(?:/[0-9]+)?/files/(script|style)/?',
+  _base ~ '/api(?:/[0-9]+)?/staticContent/logo_[^/]+',
+] %}
+{% endif %}
+ProxyPassInterpolateEnv On
+{% for pattern in ns.patterns %}
+<LocationMatch "^(?<full>{{ pattern }})$">
+    Require all granted
+    ProxyPreserveHost On
+    ProxyPassMatch "http://{{ _gw }}${MATCH_FULL}" interpolate
+    ProxyPassReverse "http://{{ _gw }}/"
+    RequestHeader set X-DHIS2-Upstream "http://{{ _inst }}"
+    RequestHeader set X-Forwarded-Port "{{ https_port | default('443') }}"
+    RequestHeader set X-Forwarded-Proto "https"
+</LocationMatch>
+{% endfor %}
+{% endif %}

--- a/deploy/roles/create-instance/templates/clamav/nginx_locations.j2
+++ b/deploy/roles/create-instance/templates/clamav/nginx_locations.j2
@@ -1,0 +1,34 @@
+{% set _clamav_on = (clamav_enabled | default(false) | bool)
+     and (groups['clamav_servers'] | default([]) | length > 0) %}
+{% if _clamav_on %}
+{% set _base = '' if (hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string == 'ROOT')
+     else '/' ~ (hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string) %}
+{% set ns = namespace(patterns=[
+  _base ~ '/api(?:/[0-9]+)?/fileResources/?',
+  _base ~ '/api(?:/[0-9]+)?/dataValues/file/?',
+  _base ~ '/api(?:/[0-9]+)?/messageConversations/attachments/?',
+]) %}
+{% if clamav_scan_app_zips | default(true) | bool %}
+{% set ns.patterns = ns.patterns + [_base ~ '/api(?:/[0-9]+)?/apps/?'] %}
+{% endif %}
+{% if clamav_scan_ui_assets | default(true) | bool %}
+{% set ns.patterns = ns.patterns + [
+  _base ~ '/api(?:/[0-9]+)?/files/(script|style)/?',
+  _base ~ '/api(?:/[0-9]+)?/staticContent/logo_[^/]+',
+] %}
+{% endif %}
+{# Create URLs only. GET on the same path is pass-through at the gateway. #}
+{% for pattern in ns.patterns %}
+location ~ ^{{ pattern }}$ {
+   proxy_pass http://clamav_gateway;
+   include {{ clamav_proxy_params }};
+   proxy_redirect off;
+   proxy_set_header X-Forwarded-Port {{ https_port | default('443') }};
+   proxy_set_header X-DHIS2-Upstream http://{{ (hostvars[item]['service_ip'] | default(hostvars[item]['ansible_host'])) | hostport(tomcat_port | default('8080')) }};
+   proxy_hide_header Strict-Transport-Security;
+   proxy_hide_header X-Powered-By;
+   proxy_hide_header Server;
+   include {{ clamav_security_headers }};
+}
+{% endfor %}
+{% endif %}

--- a/deploy/roles/create-instance/templates/clamav/nginx_upstream.j2
+++ b/deploy/roles/create-instance/templates/clamav/nginx_upstream.j2
@@ -1,0 +1,10 @@
+{{ ansible_managed | comment }}
+{% set _clamav_on = (clamav_enabled | default(false) | bool)
+     and (groups['clamav_servers'] | default([]) | length > 0) %}
+{% if _clamav_on %}
+upstream clamav_gateway {
+    server {{ hostvars[groups['clamav_servers'][0]]['service_ip']
+       | default(hostvars[groups['clamav_servers'][0]]['ansible_host'])
+       | hostport(clamav_gateway_port | default(8081)) }};
+}
+{% endif %}

--- a/deploy/roles/create-instance/templates/nginx/instance.j2
+++ b/deploy/roles/create-instance/templates/nginx/instance.j2
@@ -1,5 +1,8 @@
 {% set _glowroot_enabled = app_monitoring is defined and app_monitoring | trim == 'glowroot' %}
 {% set _glowroot_locked = wireguard_monitoring_locked | default(false) | bool %}
+{% set clamav_proxy_params = '/etc/nginx/proxy_params' %}
+{% set clamav_security_headers = '/etc/nginx/security_headers.conf' %}
+{% include 'clamav/nginx_locations.j2' %}
 {% if  hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string == "ROOT"  %}
 location / {
    proxy_pass  http://{{ item | replace('-', '_') }}_tomcat;

--- a/deploy/roles/create-instance/templates/openresty/instance.j2
+++ b/deploy/roles/create-instance/templates/openresty/instance.j2
@@ -1,3 +1,6 @@
+{% set clamav_proxy_params = '/usr/local/openresty/nginx/conf/proxy_params' %}
+{% set clamav_security_headers = '/usr/local/openresty/nginx/conf/security_headers.conf' %}
+{% include 'clamav/nginx_locations.j2' %}
 {% if  hostvars[item]['dhis2_base_path'] | default(item) | to_fixed_string == "ROOT"  %}
 location / {
    proxy_pass  http://{{ item | replace('-', '_') }}_tomcat;

--- a/deploy/roles/monitoring/templates/scrape-configs.j2
+++ b/deploy/roles/monitoring/templates/scrape-configs.j2
@@ -20,3 +20,11 @@
       - targets:
           - {{ lxd_network.split('/')[0] }}:9100
 {% endif %}
+{% if (clamav_enabled | default(false) | bool) and (groups['clamav_servers'] | default([]) | length > 0) %}
+  - job_name: clamav
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - {{ hostvars[groups['clamav_servers'][0]]['service_ip']
+             | default(hostvars[groups['clamav_servers'][0]]['ansible_host']) }}:{{ clamav_gateway_port | default(8081) }}
+{% endif %}

--- a/deploy/roles/wireguard/tasks/validate.yml
+++ b/deploy/roles/wireguard/tasks/validate.yml
@@ -205,6 +205,24 @@
   when: wireguard_data_plane | default(false) | bool
   run_once: true
 
+- name: WireGuard | Assert clamav servers have wireguard_ip when data plane is enabled
+  ansible.builtin.assert:
+    that:
+      - hostvars[item].wireguard_ip is defined
+      - hostvars[item].wireguard_ip | length > 0
+    fail_msg: >-
+      Host '{{ item }}' is in [clamav_servers] but has no wireguard_ip while
+      wireguard_data_plane is true. With the data plane active the proxy
+      reaches the scanner via service_ip (wireguard_ip), so the clamav host
+      must be a WireGuard peer. Add 'wireguard_ip=<10.0.0.x>' to the clamav
+      host, or disable wireguard_data_plane.
+    quiet: true
+  loop: "{{ groups.get('clamav_servers', []) | sort }}"
+  loop_control:
+    label: "{{ item }}"
+  when: wireguard_data_plane | default(false) | bool
+  run_once: true
+
 - name: WireGuard | Assert every app host (web/databases/instances/monitoring) has wireguard_ip
   ansible.builtin.assert:
     that:

--- a/docs/Reverse-Proxy.md
+++ b/docs/Reverse-Proxy.md
@@ -131,7 +131,13 @@ cetificate location/.
 These files hold upstream configuration files that proxy pass requests to
 dhis2, munin and glowroot application monitor.
 
-These files are loaded from the main configuration file. 
+These files are loaded from the main configuration file.
+
+## Upload scanning
+
+When `clamav_enabled=true` and `[clamav_servers]` has a host, the proxy
+sends DHIS2 file-create URLs to a scan-and-forward gateway. Other traffic
+is unchanged. See [ClamAV upload scanning](clamav.md).
  
 
 

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -199,6 +199,19 @@ munin_users:
     password: user2_passsword
 ```
 
+### ClamAV upload scanning
+
+Opt-in. Off by default. See [ClamAV upload scanning](clamav.md).
+
+| Variable | Default | Comments |
+|:---------|:--------|:---------|
+| `clamav_enabled` | `false` | Master gate. Needs a `[clamav_servers]` host and about 4 GiB extra RAM. |
+| `clamav_fail_open` | `false` | Break-glass: allow uploads if clamd is down. |
+| `clamav_scan_app_zips` | `true` | Intercept `POST /api/apps`. |
+| `clamav_scan_ui_assets` | `true` | Intercept custom JS/CSS and logo uploads. |
+| `clamav_gateway_port` | `8081` | Gateway listen port on the LXD bridge (or clamav VM). |
+| `clamav_private_mirror` | unset | Air-gapped freshclam mirror. Empty uses `database.clamav.net`. |
+
 ### backup related Variables
 These variables pertain to the PostgreSQL database host and contain sensitive
 information. It is advisable to secure them using ansible-vault encryption. You

--- a/docs/clamav.md
+++ b/docs/clamav.md
@@ -1,0 +1,106 @@
+# ClamAV upload scanning
+
+Opt-in malware scan of files uploaded to DHIS2 through the web UI or mobile
+apps. The reverse proxy sends create-upload URLs to a dedicated scanner host;
+everything else still goes straight to Tomcat.
+
+Default installs are unchanged. `clamav_enabled` is false, and an empty
+`[clamav_servers]` group is fine.
+
+## What is scanned
+
+Per-instance create URLs only (versioned API included):
+
+- `/api/fileResources`
+- `/api/dataValues/file`
+- `/api/messageConversations/attachments`
+- `/api/apps` when `clamav_scan_app_zips=true`
+- `/api/files/script`, `/api/files/style`, and `/api/staticContent/logo_*`
+  when `clamav_scan_ui_assets=true`
+
+`GET` on those same URLs is not scanned. UID/download paths and
+`POST /api/tracker` are not intercepted (tracker carries FileResource UIDs
+whose bytes already went through `/api/fileResources`).
+
+The gateway does not re-encode multipart. File parts are extracted and
+scanned as raw bytes; the original request is forwarded so DHIS2's MD5 of
+the stored bytes still matches.
+
+## Requirements
+
+- A host in `[clamav_servers]`
+- About 4 GiB extra RAM on the LXD hypervisor (or on the clamav VM in SSH
+  mode). The playbook measures **host** `MemAvailable` before creating the
+  LXD container. Many 8 GiB single-server hosts cannot enable this without a
+  RAM upgrade.
+- Official Cisco CVD/CDIFF signatures via Ubuntu `clamav-freshclam`. No
+  third-party PPA or unofficial signature packs.
+
+The scanner is not published on the host. UFW allows the gateway port from
+`[web]` (uploads) and from `[monitoring]` when Prometheus is in use.
+
+## Inventory
+
+```ini
+[clamav_servers]
+clamav  ansible_host=172.19.2.40  wireguard_ip=10.0.0.8
+
+[all:vars]
+clamav_enabled=true
+# clamav_fail_open=false
+# clamav_scan_app_zips=true
+# clamav_scan_ui_assets=true
+# clamav_gateway_port=8081
+# clamav_private_mirror=
+```
+
+Do not use `wireguard_ip=10.0.0.6`. That address is the default sysadmin
+peer. When `wireguard_data_plane=true`, the clamav host must have its own
+`wireguard_ip`.
+
+## Variables
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `clamav_enabled` | `false` | Master gate |
+| `clamav_fail_open` | `false` | Break-glass: allow uploads if clamd is down |
+| `clamav_scan_app_zips` | `true` | `POST /api/apps` |
+| `clamav_scan_ui_assets` | `true` | Custom JS/CSS and logos |
+| `clamav_gateway_port` | `8081` | Bridge listen port |
+| `clamav_private_mirror` | unset | Air-gapped freshclam mirror |
+
+## Failure behaviour
+
+- Infected upload: `403` JSON (`malware_detected` plus the signature name).
+  Bytes are not forwarded to Tomcat.
+- clamd or the gateway down: `503` (fail-closed). Set `clamav_fail_open=true`
+  only as break-glass.
+- Unknown or missing `X-DHIS2-Upstream`: `502`. The proxy overwrites that
+  header; the gateway allowlists `[instances]` `service_ip` plus
+  `tomcat_port` (default 8080). Adding or moving an instance refreshes
+  that list during `create-instance` (and on `--tags clamav-configure`).
+- Truncated upload bodies (client sent fewer bytes than `Content-Length`)
+  are rejected with `400` and are not forwarded. The proxy is expected to
+  buffer the request (`proxy_request_buffering` stays on) so the gateway
+  sees `Content-Length`.
+
+Stale signatures alert, they do not fail-closed. `/healthz` is a clamd
+`PING` only. Signature age is exposed on `/metrics` so Prometheus can alert
+without taking the scanner out of rotation.
+
+Air-gapped hosts: set `clamav_private_mirror`, or copy `main.cvd`,
+`daily.cvd`, and `bytecode.cvd` into `/var/lib/clamav` on the scanner.
+Signature age over 48 hours is a freshness problem; scans still use the last
+good database.
+
+## Tags
+
+```bash
+ansible-playbook dhis2.yml --tags clamav
+ansible-playbook dhis2.yml --tags clamav-install
+ansible-playbook dhis2.yml --tags clamav-configure
+```
+
+Proxy location, Tomcat UFW, and the gateway upstream allowlist live in
+`create-instance`. A full playbook run (or `--tags create-instance` after
+the scanner is up) applies them.


### PR DESCRIPTION
## Summary

- Adds an optional ClamAV scanner host (`[clamav_servers]`, `clamav_enabled=false` by default) that sits behind nginx/apache/OpenResty.
- Create-upload URLs (`/api/fileResources`, `/api/dataValues/file`, attachments, optional apps and UI assets) go to `clamav_gateway.py`. Everything else still goes to Tomcat.
- The gateway copies `filename=` parts, scans them with clamd, and forwards the **original** request so DHIS2 `contentMd5` still matches the client bytes.
- Fail-closed: infected → `403 malware_detected`; clamd down → `503`. Stale signatures do not fail-closed; age is on `/metrics`.
- Default installs are unchanged (empty group / flag off). Needs ~4 GiB extra RAM. Official Cisco CVD/CDIFF only.

See `docs/clamav.md`.

## Test plan

### 1. Gateway unit tests

```bash
python3 deploy/roles/clamav/files/test_clamav_gateway.py -v
```

Expect 15 tests OK. They mock a unix-socket clamd and use the EICAR string.

### 2. Lint

```bash
ansible-lint deploy/roles/clamav deploy/dhis2.yml
```

Default Molecule should still pass: the role no-ops when `clamav_enabled` is false or `[clamav_servers]` is empty.

### 3. Enable on a lab / VM (LXD)

In `deploy/inventory/hosts`:

```ini
[clamav_servers]
clamav  ansible_host=172.19.2.40  wireguard_ip=10.0.0.8

[all:vars]
clamav_enabled=true
```

Do not use `wireguard_ip=10.0.0.6` (sysadmin peer). Confirm the hypervisor has ~4 GiB free RAM; the role pre-flights `MemAvailable` before creating the container.

```bash
cd deploy
sudo ./deploy.sh
# or, if the stack is already up:
ansible-playbook dhis2.yml --tags clamav,create-instance
```

Confirm:

- Container `clamav` exists; `clamav-daemon`, `clamav-freshclam`, and `clamav-gateway` are active.
- `freshclam.conf` points at `database.clamav.net` (or `clamav_private_mirror`).
- `nginx -t` / apache config test succeeds.
- Gateway listen is `8081` on the LXD bridge, not published on the host.

### 4. Functional checks

Replace `BASE` with the instance URL (including base path, e.g. `https://example.org/dhis`).

**Clean upload** — expect `202`, and `contentMd5` of the stored file equals `md5sum` of the local file:

```bash
echo 'hello' > /tmp/clean.txt
curl -sk -u admin:district -F 'file=@/tmp/clean.txt' "$BASE/api/fileResources"
```

**EICAR** — expect `403` with `"error":"malware_detected"` and `"signature":"Eicar-Test-Signature"`. Bytes must not reach Tomcat.

```bash
printf 'X5O!P%%@AP[4\\PZX54(P^^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > /tmp/eicar.com
curl -sk -u admin:district -F 'file=@/tmp/eicar.com' "$BASE/api/fileResources"
curl -sk -u admin:district -F 'file=@/tmp/eicar.com' "$BASE/api/42/fileResources"
```

Also try the same POST with a browser session cookie (`/api/auth/login`), not only basic auth.

**Passthrough**

- `GET $BASE/api/fileResources` goes through the gateway (no scan) to Tomcat.
- `GET $BASE/api/dataValues/files` is **not** intercepted (download path).

**Fail-closed** — stop both the socket and the service (Ubuntu socket activation restarts clamd if you only stop the service):

```bash
lxc exec clamav -- systemctl stop clamav-daemon.socket clamav-daemon.service
curl -sk -u admin:district -F 'file=@/tmp/clean.txt' "$BASE/api/fileResources"
# expect 503 scanner_unavailable
lxc exec clamav -- systemctl start clamav-daemon.socket clamav-daemon.service
```

**Health / metrics** (from the proxy or monitor host, not from postgres):

```bash
curl -s http://172.19.2.40:8081/healthz
curl -s http://172.19.2.40:8081/metrics
# clamav_scans_total, clamav_infected_total, clamav_clamd_up, clamav_signature_age_seconds
```

### 5. Optional

- `POST $BASE/api/apps` with a non-malware zip: forwarded to Tomcat (often `409` missing manifest). Malware zip should `403`.
- If Prometheus is running: scrape job `clamav` on `:8081/metrics`.
- If `wireguard_data_plane=true`: clamav must be a WireGuard peer with its own `wireguard_ip`.