### PR TITLE
fix(backups): stop world-readable pg dumps

### DIFF
--- a/deploy/roles/backups/tasks/backups.yml
+++ b/deploy/roles/backups/tasks/backups.yml
@@ -85,6 +85,19 @@
     mode: "0750"
   when: inventory_hostname in groups['backup_servers']
 
+- name: Ensure /var/pgbackups is not world-readable
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop:
+    - /var/pgbackups
+    - /var/pgbackups/db-backup
+    - /var/pgbackups/audit-backup
+  when: inventory_hostname in groups['backup_servers']
+
 - name: Create dhis2-env from template
   ansible.builtin.template:
     src: dhis2-env-new.j2

--- a/deploy/roles/backups/tasks/lxd.yml
+++ b/deploy/roles/backups/tasks/lxd.yml
@@ -14,6 +14,18 @@
     group: root
     mode: "0750"
 
+- name: Ensure /var/pgbackups is not world-readable
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop:
+    - /var/pgbackups
+    - /var/pgbackups/db-backup
+    - /var/pgbackups/audit-backup
+
 # s3_cluster ids
 - name: Configuring s3
   ansible.builtin.include_tasks: s3cfg.yml

--- a/deploy/roles/backups/tasks/ssh.yml
+++ b/deploy/roles/backups/tasks/ssh.yml
@@ -11,6 +11,18 @@
     group: root
     mode: "0750"
 
+- name: Ensure /var/pgbackups is not world-readable
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop:
+    - /var/pgbackups
+    - /var/pgbackups/db-backup
+    - /var/pgbackups/audit-backup
+
 - name: Configuring s3
   ansible.builtin.include_tasks: s3cfg.yml
   when:

--- a/deploy/roles/backups/templates/backup-script
+++ b/deploy/roles/backups/templates/backup-script
@@ -16,9 +16,17 @@ set -euo pipefail
 # load environment variables
 source /usr/local/etc/dhis/dhis2-env-new
 
+umask ${UMASK:-027}
+
+restrict_backup_dir() {
+  [ -d "$BACKUP_DIR" ] || return 0
+  chmod -R u=rwX,g=rX,o= "$BACKUP_DIR"
+}
+
 # Setup logging
 LOG_DIR=${LOG_DIR:-/var/log/pg_backup}
 mkdir -p "$LOG_DIR"
+chmod 0750 "$LOG_DIR"
 LOG_FILE="$LOG_DIR/pg_backup_$(date +%Y%m%d).log"
 
 # --------- helpers ----------
@@ -42,9 +50,6 @@ export PGSERVICEFILE=${PGSERVICEFILE:-/usr/local/etc/dhis/pg_service.conf}
 # Where to find your .pgpass file (passwords for pg_service.conf entries)
 # Defaults to ~/.pgpass which is the PostgreSQL standard location
 export PGPASSFILE=${PGPASSFILE:-~/.pgpass}
-
-# Basic safety & umask (directories 750, files 640)
-umask ${UMASK:-027}
 
 # create a temp dir for in_progress files (will be cleaned on exit)
 TMPDIR=$(mktemp -d /tmp/pgmulti_backup.XXXXXX)
@@ -77,6 +82,7 @@ if [ -z "${BACKUP_DIR:-}" ]; then
   fail "BACKUP_DIR is not set in your dhis2-env"
 fi
 mkdir -p "$BACKUP_DIR"
+restrict_backup_dir
 
 # Convenience defaults (if not set in env)
 SERVICES=${SERVICES:-""}   # e.g. "prod dev"

--- a/deploy/roles/backups/templates/lxd/dhis2-backup
+++ b/deploy/roles/backups/templates/lxd/dhis2-backup
@@ -10,9 +10,12 @@
 # load variables from a file, 
 source /usr/local/etc/dhis/dhis2-env
 
-# Umask 027 ensures that backup directories are created with permissions 750,
-# and files with permissions 640.
 umask 027
+
+restrict_backup_dir() {
+  [ -d "$BACKUP_DIR" ] || return 0
+  chmod -R u=rwX,g=rX,o= "$BACKUP_DIR"
+}
 
 function perform_backups()
 {
@@ -35,6 +38,8 @@ function perform_backups()
         echo "`date` Cannot create backup directory in $FINAL_AUDIT_DIR. Go and fix it!"
         exit 1;
   fi;
+
+  restrict_backup_dir
 
   #  sudo su -c "pg_dump -O -Fp $DBNAME -T aggregated_* -T analytics_* -T completeness_*  | gzip > ./$DB_NAME.sql.gz" postgres
   for DBNAME in $PLAIN_BACKUPS 

--- a/deploy/roles/backups/templates/ssh/dhis2-backup
+++ b/deploy/roles/backups/templates/ssh/dhis2-backup
@@ -10,6 +10,13 @@
 # load variables from a file, 
 source /usr/local/etc/dhis/dhis2-env
 
+umask 027
+
+restrict_backup_dir() {
+  [ -d "$BACKUP_DIR" ] || return 0
+  chmod -R u=rwX,g=rX,o= "$BACKUP_DIR"
+}
+
 function perform_backups()
 {
   SUFFIX=$1
@@ -29,6 +36,8 @@ function perform_backups()
         echo "`date` Cannot create backup directory in $FINAL_AUDIT_DIR. Go and fix it!"
         exit 1;
   fi;
+
+  restrict_backup_dir
 
   #  sudo su -c "pg_dump -O -Fp $DBNAME -T aggregated_* -T analytics_* -T completeness_*  | gzip > ./$DB_NAME.sql.gz" postgres
   for DBNAME in $PLAIN_BACKUPS 


### PR DESCRIPTION
## Summary
- Cron umask `022` made `mkdir -p /var/pgbackups` create a world-readable tree (`755` dirs, `644` dumps). On LXD that tree lives on the hypervisor; on SSH it lives on the database host.
- Playbooks now create `/var/pgbackups` (and `db-backup` / `audit-backup`) at `0750`. Backup scripts set `umask 027` and `chmod` the tree so an existing `755` parent is repaired on the next run.

## Test plan
- [ ] Re-run `--tags backup-script` on a host that still has `755` `/var/pgbackups` and confirm `ls` fails for a non-root user
- [ ] Restore still works via `sudo /usr/local/bin/dhis2-restoredb <dump> <dbname>`