### PR TITLE
feat: set server.base.url from inventory FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ansible_connection=lxd
   sudo ./deploy.sh
   ```
 - After the script finishes running (without errors), access your DHIS2, Glowroot and Munin monitoring instances:
-  > **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address.
+  > **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address. When `fqdn` is set, that public URL is written to `/opt/dhis2/dhis.conf` as `server.base.url` (override with `server_base_url` if users reach a different name).
   ```
   https://<hostname>/dhis
   https://<hostname>/dhis-glowroot
@@ -242,7 +242,7 @@ NOTE:
 - If you don't specify an SSH username, it will automatically use currently logged in username.
 
 - After the playbook finishes running (without errors), access your DHIS2, Glowroot and Munin monitoring instances:
-  > **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address.
+  > **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address. When `fqdn` is set, that public URL is written to `/opt/dhis2/dhis.conf` as `server.base.url` (override with `server_base_url` if users reach a different name).
   ```
   https://<hostname>/dhis
   https://<hostname>/dhis-glowroot
@@ -305,7 +305,7 @@ NOTE:
 ## Conclusion
 At this point you should have DHIS2 up and running.
 
-> **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address.
+> **Note:** `<hostname>` = your `fqdn` if defined, otherwise your server's IP address. When `fqdn` is set, that public URL is written to `/opt/dhis2/dhis.conf` as `server.base.url`.
 
 - **DHIS2** — `https://<hostname>/dhis`
 - **Glowroot** — `https://<hostname>/dhis-glowroot` ([glowroot.org](https://glowroot.org/) for application performance monitoring)

--- a/changelogs/fragments/server-base-url.yml
+++ b/changelogs/fragments/server-base-url.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    create-instance - set server.base.url and server.https in dhis.conf from
+    inventory FQDN, instance path, and optional server_base_url.

--- a/deploy/filter_plugins/custom_filters.py
+++ b/deploy/filter_plugins/custom_filters.py
@@ -1,4 +1,6 @@
+import ipaddress
 import re
+from urllib.parse import urlparse
 from netaddr import IPAddress, IPNetwork
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils.common.text.converters import to_text
@@ -145,6 +147,131 @@ def external_hosts(hosts, hostvars, lxd_network):
     return result
 
 
+_LOOPBACK_NAMES = frozenset({
+    'localhost',
+    'ip6-localhost',
+    'ip6-loopback',
+    'localhost.localdomain',
+})
+
+
+def _clean_conf_value(value, name):
+    text = '' if value is None else str(value)
+    if any(ord(c) < 32 or ord(c) == 127 for c in text):
+        raise AnsibleFilterError(
+            f"{name} must not contain control characters"
+        )
+    if any(c.isspace() for c in text.strip()):
+        raise AnsibleFilterError(
+            f"{name} must not contain whitespace"
+        )
+    return text.strip()
+
+
+def _host_ip(name):
+    try:
+        return ipaddress.ip_address(name)
+    except ValueError:
+        parts = name.split('.')
+        if not (2 <= len(parts) <= 3 and all(p.isdigit() for p in parts)):
+            return None
+        padded = parts[:-1] + ['0'] * (4 - len(parts)) + parts[-1:]
+        try:
+            return ipaddress.IPv4Address('.'.join(padded))
+        except ValueError:
+            return None
+
+
+def _is_blocked_host(host):
+    if not host:
+        return True
+    name = host.strip('[]').lower()
+    if name in _LOOPBACK_NAMES:
+        return True
+    ip = _host_ip(name)
+    return ip is not None and (ip.is_loopback or ip.is_unspecified)
+
+
+def _canonical_https_url(url, source):
+    try:
+        parsed = urlparse(url)
+        port = parsed.port
+    except ValueError as exc:
+        raise AnsibleFilterError(
+            f"{source} is not a valid https URL"
+        ) from exc
+    if parsed.scheme != 'https':
+        raise AnsibleFilterError(
+            f"{source} must be an https URL"
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise AnsibleFilterError(
+            f"{source} must not contain userinfo"
+        )
+    if parsed.query or parsed.fragment:
+        raise AnsibleFilterError(
+            f"{source} must not contain a query string or fragment"
+        )
+    host = parsed.hostname
+    if host is None or _is_blocked_host(host):
+        raise AnsibleFilterError(
+            f"{source} hostname must be reachable by end users, not localhost"
+        )
+    path = parsed.path.rstrip('/')
+    if '//' in path or any(seg in ('.', '..') for seg in path.split('/')):
+        raise AnsibleFilterError(
+            f"{source} path is not a valid DHIS2 context path"
+        )
+    if ':' in host:
+        try:
+            ipaddress.IPv6Address(host)
+        except ValueError as exc:
+            raise AnsibleFilterError(
+                f"{source} hostname is not a valid IPv6 address"
+            ) from exc
+        netloc = f'[{host}]'
+    else:
+        netloc = host
+    if port is not None and port != 443:
+        netloc = f'{netloc}:{port}'
+    return f'https://{netloc}{path}'
+
+
+def dhis2_server_base_url(override, fqdn='', context='', https_port=443):
+    """Public URL for dhis.conf server.base.url, or '' when it must be omitted."""
+    override = _clean_conf_value(override, 'server_base_url')
+    if override:
+        return _canonical_https_url(override.rstrip('/'), 'server_base_url')
+
+    fqdn = _clean_conf_value(fqdn, 'fqdn')
+    if not fqdn:
+        return ''
+    if '/' in fqdn or '@' in fqdn or '://' in fqdn or ':' in fqdn:
+        raise AnsibleFilterError('fqdn must be a hostname, not a URL')
+
+    try:
+        port = int(https_port)
+    except (TypeError, ValueError) as exc:
+        raise AnsibleFilterError(
+            f"https_port must be an integer, got {https_port!r}"
+        ) from exc
+    if port < 1 or port > 65535:
+        raise AnsibleFilterError(f"https_port must be 1-65535, got {port}")
+
+    raw_context = 'ROOT' if context in (None, '') else context
+    context_s = _clean_conf_value(to_fixed_string(raw_context), 'dhis2_base_path')
+    if context_s != 'ROOT' and (
+            context_s.startswith('/') or '/' in context_s
+            or context_s in ('.', '..')):
+        raise AnsibleFilterError(
+            'dhis2_base_path must be a single path segment or ROOT'
+        )
+
+    netloc = fqdn if port == 443 else f'{fqdn}:{port}'
+    path = '' if context_s == 'ROOT' else f'/{context_s}'
+    return _canonical_https_url(f'https://{netloc}{path}', 'fqdn')
+
+
 class FilterModule(object):
     def filters(self):
         return {'get_dhis2_instance_specs': get_dhis2_instance_specs,
@@ -154,4 +281,5 @@ class FilterModule(object):
                 'tomcat_version': tomcat_version,
                 'normalize_dhis2_version': normalize_dhis2_version,
                 'all_have_fqdn': all_have_fqdn,
+                'dhis2_server_base_url': dhis2_server_base_url,
                 }

--- a/deploy/filter_plugins/custom_filters.py
+++ b/deploy/filter_plugins/custom_filters.py
@@ -192,6 +192,18 @@ def _is_blocked_host(host):
     return ip is not None and (ip.is_loopback or ip.is_unspecified)
 
 
+def _https_netloc(host, source):
+    if ':' not in host:
+        return host
+    try:
+        ipaddress.IPv6Address(host)
+    except ValueError as exc:
+        raise AnsibleFilterError(
+            f"{source} hostname is not a valid IPv6 address"
+        ) from exc
+    return f'[{host}]'
+
+
 def _canonical_https_url(url, source):
     try:
         parsed = urlparse(url)
@@ -222,16 +234,7 @@ def _canonical_https_url(url, source):
         raise AnsibleFilterError(
             f"{source} path is not a valid DHIS2 context path"
         )
-    if ':' in host:
-        try:
-            ipaddress.IPv6Address(host)
-        except ValueError as exc:
-            raise AnsibleFilterError(
-                f"{source} hostname is not a valid IPv6 address"
-            ) from exc
-        netloc = f'[{host}]'
-    else:
-        netloc = host
+    netloc = _https_netloc(host, source)
     if port is not None and port != 443:
         netloc = f'{netloc}:{port}'
     return f'https://{netloc}{path}'

--- a/deploy/inventory/hosts.template
+++ b/deploy/inventory/hosts.template
@@ -37,7 +37,11 @@ backup  ansible_host=172.19.2.100
 # variables applying to all hosts, 
 [all:vars]
 # if you do not set fqdn, you dhis2 will be set up with selfsigned certificate
+# and server.base.url is left unset in dhis.conf
 fqdn=
+# Override the public URL written to dhis.conf (https, no trailing slash).
+# Default is https://<fqdn>[/<instance-or-dhis2_base_path>]; include :port when https_port is not 443.
+# server_base_url=https://cdn.example.org/dhis
 # required for LetsEncrypt certificate notification. 
 email=
 

--- a/deploy/roles/create-instance/defaults/main/main.yml
+++ b/deploy/roles/create-instance/defaults/main/main.yml
@@ -13,6 +13,10 @@ database_host: postgres
 # default dhis2_version
 dhis2_version: 2.42
 
+# Public URL written to dhis.conf as server.base.url. Leave empty to derive
+# https://<fqdn>[/<instance>] when fqdn is set. HTTPS only, no trailing slash.
+# server_base_url: https://cdn.example.org/dhis
+
 # required postgresql extensions
 postgresql_version: 16
 

--- a/deploy/roles/create-instance/tasks/tomcat-setup.yml
+++ b/deploy/roles/create-instance/tasks/tomcat-setup.yml
@@ -39,7 +39,7 @@
     modification_time: preserve
     access_time: preserve
 
-- name: Copy dhis2.conf to the instances
+- name: Instance | Template dhis.conf
   ansible.builtin.template:
     src: dhis.conf.j2
     dest: /opt/dhis2/dhis.conf
@@ -47,7 +47,6 @@
     owner: root
     group: tomcat
   when: db_password is defined
-  ignore_errors: true  # ignore errors so it works even wen db_password is not defined
   notify: Restart Tomcat
 
 - name: Copy server.xml to the instances

--- a/deploy/roles/create-instance/templates/dhis.conf.j2
+++ b/deploy/roles/create-instance/templates/dhis.conf.j2
@@ -45,7 +45,14 @@ db.pool.type = hikari
 # SQL view protected tables, can be 'on', 'off'
 # system.sql_view_table_protection = on
 
-# server.base.url = https://play.dhis2.org/dev
+{% set _server_base_url = server_base_url | default('') | dhis2_server_base_url(
+     fqdn | default(''),
+     dhis2_base_path | default(inventory_hostname, true),
+     https_port | default(443)) %}
+{% if _server_base_url | length > 0 %}
+server.base.url = {{ _server_base_url }}
+server.https = on
+{% endif %}
 
 # ----------------------------------------------------------------------
 # Encryption

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -80,7 +80,15 @@ dhis2_version: 2.39
   </tr>
   <tr>
     <td style="vertical-align: top; text-align: left;"> <code>fqdn</code></td>
-    <td> This is the domain used to access dhis2 application <br>Strictly required for Letsencrypt to work </td>
+    <td> This is the domain used to access dhis2 application <br>Strictly required for Letsencrypt to work. When set, Ansible writes <code>server.base.url</code> and <code>server.https = on</code> into <code>dhis.conf</code>.</td>
+  </tr>
+  <tr>
+    <td style="vertical-align: top; text-align: left;"> <code>server_base_url</code></td>
+    <td> Optional override for <code>server.base.url</code> in <code>dhis.conf</code> (CDN or a public hostname that is not inventory <code>fqdn</code>). Must be an absolute <code>https://</code> URL with no trailing slash. If unset, the value is <code>https://&lt;fqdn&gt;[/&lt;dhis2_base_path or instance name&gt;]</code>, with <code>https_port</code> appended when it is not 443. The key is omitted when <code>fqdn</code> is empty.</td>
+  </tr>
+  <tr>
+    <td style="vertical-align: top; text-align: left;"> <code>dhis2_base_path</code></td>
+    <td> Public path of the instance. Defaults to the inventory hostname. Use <code>ROOT</code> to serve at <code>/</code> (no extra path, no trailing slash on <code>server.base.url</code>).</td>
   </tr>
   <tr>
     <td style="vertical-align: top; text-align: left;"><code>create_db</code></td>

--- a/tests/unit/test_dhis2_server_base_url.py
+++ b/tests/unit/test_dhis2_server_base_url.py
@@ -1,0 +1,85 @@
+"""URL construction for dhis.conf server.base.url."""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_FILTERS = Path(__file__).resolve().parents[2] / "deploy" / "filter_plugins" / "custom_filters.py"
+_spec = importlib.util.spec_from_file_location("custom_filters", _FILTERS)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["custom_filters"] = _mod
+_spec.loader.exec_module(_mod)
+
+dhis2_server_base_url = _mod.dhis2_server_base_url
+AnsibleFilterError = _mod.AnsibleFilterError
+
+
+@pytest.mark.parametrize(
+    "override,fqdn,context,port,expected",
+    [
+        ("", "hmis.moh.gov", "dhis", 443, "https://hmis.moh.gov/dhis"),
+        ("", "same.example.org", "hmis", 443, "https://same.example.org/hmis"),
+        ("", "same.example.org", "training", 443, "https://same.example.org/training"),
+        ("", "fqdn.example.org", "dhis2", 443, "https://fqdn.example.org/dhis2"),
+        ("", "fqdn.example.org", "ROOT", 443, "https://fqdn.example.org"),
+        ("", "fqdn.example.org", "dhis", 8443, "https://fqdn.example.org:8443/dhis"),
+        ("", "", "dhis", 443, ""),
+        ("", "   ", "dhis", 443, ""),
+        (
+            "https://cdn.example.org/dhis/",
+            "ignored.example.org",
+            "dhis",
+            443,
+            "https://cdn.example.org/dhis",
+        ),
+        (
+            "https://cdn.example.org:443/dhis",
+            "",
+            "ROOT",
+            443,
+            "https://cdn.example.org/dhis",
+        ),
+        ("", "play.example.org", 2.4, 443, "https://play.example.org/2.40"),
+        ("", "play.example.org", "", 443, "https://play.example.org"),
+        ("", "hmis.moh.gov", "dhis", "443", "https://hmis.moh.gov/dhis"),
+    ],
+)
+def test_builds_public_url(override, fqdn, context, port, expected):
+    assert dhis2_server_base_url(override, fqdn, context, port) == expected
+
+
+@pytest.mark.parametrize(
+    "override,fqdn,context,port",
+    [
+        ("http://insecure.example.org/dhis", "", "dhis", 443),
+        ("https://localhost/dhis", "", "dhis", 443),
+        ("https://127.0.0.1/dhis", "", "dhis", 443),
+        ("https://user:pass@evil.example.org/dhis", "", "dhis", 443),
+        ("https://ok.example.org/dhis?next=https://evil", "", "dhis", 443),
+        ("https://ok.example.org/dhis#frag", "", "dhis", 443),
+        ("https://ok.example.org/dhis\nconnection.password=x", "", "dhis", 443),
+        ("javascript:alert(1)", "", "dhis", 443),
+        ("", "https://not-a-host.example.org", "dhis", 443),
+        ("", "host.example.org:8443", "dhis", 443),
+        ("", "ok.example.org", "../etc", 443),
+        ("", "ok.example.org", "foo/bar", 443),
+        ("", "ok.example.org", "dhis", 0),
+        ("", "ok.example.org", "dhis", 70000),
+        ("", "ok.example.org", "dhis", "none"),
+        ("https://ok.example.org/dhis extra", "", "dhis", 443),
+        ("https://0.0.0.0/dhis", "", "dhis", 443),
+        ("https://[::]/dhis", "", "dhis", 443),
+        ("https://127.1/dhis", "", "dhis", 443),
+        ("https://example.com:99999/dhis", "", "dhis", 443),
+        ("https://example.com:abc/dhis", "", "dhis", 443),
+        ("https://ok.example.org/dhis\x1b", "", "dhis", 443),
+        ("https://ok.example.org/dhis\x7f", "", "dhis", 443),
+        ("", "2001:db8::1", "dhis", 443),
+        ("", "0.0.0.0", "dhis", 443),
+        ("", "127.1", "dhis", 443),
+    ],
+)
+def test_rejects_unsafe_values(override, fqdn, context, port):
+    with pytest.raises(AnsibleFilterError):
+        dhis2_server_base_url(override, fqdn, context, port)


### PR DESCRIPTION
## Summary
- Write `server.base.url` and `server.https = on` into `/opt/dhis2/dhis.conf` from inventory `fqdn` and instance path (`dhis2_base_path` or hostname). Empty `fqdn` omits the key; `server_base_url` overrides (HTTPS, no trailing slash).
- Reject localhost/unspecified hosts, control characters, userinfo, and invalid ports in the URL filter so a bad value cannot land in `dhis.conf`.
- First apply rewrites `dhis.conf` and restarts Tomcat (same as any other template change to that file).

## Test plan
- [x] `pytest tests/unit/test_dhis2_server_base_url.py` (39 cases)
- [x] Fresh LXD deploy on lab: play `failed=0`; `/api/system/info` `instanceBaseUrl` matches specified FQDN.
- [ ] Re-run create-instance on an existing host and confirm Tomcat restart plus `dhis.conf` keeps the derived URL
- [ ] Confirm empty `fqdn=` still leaves `server.base.url` unset