### PR TITLE
fix(doris): stop crashing fresh installs that don't use Doris

### DIFF
--- a/deploy/dhis2.yml
+++ b/deploy/dhis2.yml
@@ -26,7 +26,8 @@
       # on inventory group membership.
       when: >-
         groups['instances']
-        | map('extract', hostvars, 'apache_doris_db')
+        | map('extract', hostvars)
+        | map(attribute='apache_doris_db', default=false)
         | select('string') | list | length > 0
     - role: proxy
       tags: [proxy-install]

--- a/deploy/roles/doris/tasks/main.yml
+++ b/deploy/roles/doris/tasks/main.yml
@@ -8,7 +8,7 @@
 # visited. Resolved here, before routing, since both connection paths need them.
 - name: Determine which hosts are configured as a Doris backend
   ansible.builtin.set_fact:
-    doris_instance_map: "{{ groups['instances'] | map('extract', hostvars, 'apache_doris_db') | select('string') | list }}"
+    doris_instance_map: "{{ groups['instances'] | map('extract', hostvars) | map(attribute='apache_doris_db', default=false) | select('string') | list }}"
 
 - name: Determine whether this host is the configured Doris host
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
- The doris role's gating `when:` crashed the entire `dhis2.yml` play, for every host, on any inventory that doesn't configure Doris at all - i.e. almost every deployment. Fatal error: `object of type 'HostVarsVars' has no attribute 'apache_doris_db'`.
- Root cause: `map('extract', hostvars, 'apache_doris_db')` does a raw Python lookup internally rather than going through Ansible's normal template-rendering path, so when no host anywhere defines `apache_doris_db` it raises an uncaught `AttributeError` instead of treating it as undefined.
- This was introduced in `3f859c2` (SSH-host support), which tightened the original, safe gate from #88 (`groups['apache_doris'] | length > 0`, wired by @jason-p-pickering) into `map('extract', hostvars, 'apache_doris_db')` to stay consistent with `doris_instance_map`'s logic - the refinement introduced this crash, the original wasn't broken.
- Fix: split into `map('extract', hostvars)` (safe) then `map(attribute='apache_doris_db', default=false)` (goes through Jinja's normal safe attribute lookup). Note `default=None` does **not** work here - Jinja treats `None` as its internal "no default given" sentinel, so it still crashes the same way.
- Applied in both places with the same pattern: `deploy/dhis2.yml` (role-level gate) and `deploy/roles/doris/tasks/main.yml` (`doris_instance_map`).

## Test plan
- [x] Reproduced locally with a throwaway inventory: old expression crashes with the exact reported error, new one skips cleanly
- [x] Confirmed the new expression still correctly triggers when a host *does* set `apache_doris_db`
- [x] Verified against the real inventory that surfaced this (104.105.9.136, empty `[apache_doris]` group, no `apache_doris_db` set anywhere) via `ansible-playbook dhis2.yml --check --tags doris-install` - crash gone, doris role skips as expected for every host

🤖 Generated with [Claude Code](https://claude.com/claude-code)